### PR TITLE
docs: enforce PR single responsibility principle

### DIFF
--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -14,12 +14,19 @@ Note: Attribution disabled globally via ~/.claude/settings.json.
 
 ## Pull Request Workflow
 
+**Single Responsibility Principle (CRITICAL):**
+- Each PR must address ONE specific concern only
+- Do NOT combine unrelated changes (e.g., feature + docs update, bug fix + refactor)
+- If changes are unrelated, create separate PRs
+- Example: Stop tracking a file should not include documentation updates
+
 When creating PRs:
 1. Analyze full commit history (not just latest commit)
 2. Use `git diff [base-branch]...HEAD` to see all changes
 3. Draft comprehensive PR summary
 4. Include test plan with TODOs
 5. Push with `-u` flag if new branch
+6. Verify PR contains only related changes
 
 ## Feature Implementation Workflow
 


### PR DESCRIPTION
## Summary
- Add critical rule requiring each PR to address one specific concern only
- Prevents combining unrelated changes (e.g., feature + docs, bug fix + refactor)
- Adds verification step to ensure PR contains only related changes

## Changes
- Added **Single Responsibility Principle (CRITICAL)** section to git-workflow.md
- Added step 6: "Verify PR contains only related changes" to PR workflow checklist
- Includes concrete example: Stop tracking a file should not include documentation updates

## Test Plan
- [x] Build passes
- [x] TypeScript check passes
- [x] Documentation is clear and actionable

🤖 Generated with [Claude Code](https://claude.com/claude-code)