### PR TITLE
docs: add git workflow guide to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,14 @@ npm run start   # プロダクションサーバー起動
 npm run lint    # ESLintでコードチェック
 ```
 
+## Git Workflow
+
+**Use `/worktree` skill** for non-trivial implementation tasks (features, fixes, refactoring).
+
+**Skip worktree for:** Single-line fixes, typos, trivial edits in current branch.
+
+**Workflow:** `/worktree` → implement → `/commit` → `/pr`
+
 ## Directory Structure
 
 ```


### PR DESCRIPTION
## Summary
- Add Git Workflow section to CLAUDE.md for quick reference
- Documents when to use `/worktree` skill vs. direct commits
- Provides clear workflow: `/worktree` → `/commit` → `/pr`

## Changes
- Added **Git Workflow** section after Commands section
- Specifies to use `/worktree` for non-trivial implementation tasks
- Defines exceptions: single-line fixes, typos, trivial edits

## Test Plan
- [x] Build passes
- [x] TypeScript check passes
- [x] Documentation follows existing CLAUDE.md structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)