### PR TITLE
docs: add auto-merge permission for PRs

### DIFF
--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -20,6 +20,11 @@ Note: Attribution disabled globally via ~/.claude/settings.json.
 - If changes are unrelated, create separate PRs
 - Example: Stop tracking a file should not include documentation updates
 
+**Auto-Merge Permission:**
+- You have permission to merge PRs automatically after creation
+- Merge immediately for: small fixes, docs updates, config changes
+- Wait for user approval for: breaking changes, architecture decisions, new features
+
 When creating PRs:
 1. Analyze full commit history (not just latest commit)
 2. Use `git diff [base-branch]...HEAD` to see all changes
@@ -27,6 +32,7 @@ When creating PRs:
 4. Include test plan with TODOs
 5. Push with `-u` flag if new branch
 6. Verify PR contains only related changes
+7. Merge PR if appropriate (see Auto-Merge Permission above)
 
 ## Feature Implementation Workflow
 


### PR DESCRIPTION
## Summary
- Document permission to automatically merge PRs after creation
- Clarify when to auto-merge vs. wait for user approval
- Add step 7 to PR workflow checklist

## Changes
- Added **Auto-Merge Permission** section to git-workflow.md
- Auto-merge allowed for: small fixes, docs updates, config changes
- User approval required for: breaking changes, architecture decisions, new features
- Added step 7: "Merge PR if appropriate" to PR workflow

## Test Plan
- [x] Documentation is clear and actionable
- [x] Covers appropriate use cases for auto-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)