### PR TITLE
fix: resolve ESLint code errors

### DIFF
--- a/src/app/listing/[id]/edit/page.tsx
+++ b/src/app/listing/[id]/edit/page.tsx
@@ -170,7 +170,7 @@ export default function EditListingPage() {
     if (areaName) {
       return `${areaName}の${livingType}部屋`;
     }
-    return `${livingType}部屋` || "部屋";
+    return `${livingType}部屋`;
   };
 
   const handleSave = async () => {

--- a/src/app/listing/[id]/pdf/page.tsx
+++ b/src/app/listing/[id]/pdf/page.tsx
@@ -306,7 +306,7 @@ export default function LandlordPDFPage() {
               <div>
                 <p className="text-sm text-gray-500 mb-2">同意日</p>
                 <div className="border-b border-gray-400 pb-1 h-8">
-                  <span className="text-sm text-gray-400">　　　　年　　　月　　　日</span>
+                  <span className="text-sm text-gray-400">    年   月   日</span>
                 </div>
               </div>
               <div>

--- a/src/app/listing/new/page.tsx
+++ b/src/app/listing/new/page.tsx
@@ -136,7 +136,7 @@ export default function NewListingPage() {
     if (areaName) {
       return `${areaName}の${livingType}部屋`;
     }
-    return `${livingType}あなたの部屋` || "あなたの部屋";
+    return `${livingType}あなたの部屋`;
   };
 
   // 日付を文字列にフォーマット（単体なら「〇〇日以降」、範囲なら「〇〇日 - 〇〇日」）


### PR DESCRIPTION
## Summary
- Remove redundant `|| fallback` in constant template string expressions
- Replace full-width spaces with regular spaces in PDF date template

## Changes
- [listing/[id]/edit/page.tsx:173](src/app/listing/[id]/edit/page.tsx#L173) - Remove `|| "部屋"` from constant template string
- [listing/[id]/pdf/page.tsx:309](src/app/listing/[id]/pdf/page.tsx#L309) - Replace full-width spaces with regular spaces
- [listing/new/page.tsx:139](src/app/listing/new/page.tsx#L139) - Remove `|| "あなたの部屋"` from constant template string

## Test Plan
- [x] ESLint passes with 0 errors
- [x] TypeScript check passes
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)