### PR TITLE
fix: remove unnecessary border from map section

### DIFF
--- a/src/app/listings/[id]/page.tsx
+++ b/src/app/listings/[id]/page.tsx
@@ -153,7 +153,7 @@ export default async function PropertyDetailPage({
 
             {/* Map Section - Full Grid Width (5 columns) */}
             {property.location && (
-              <div className="lg:col-span-5 pt-4 border-t border-border">
+              <div className="lg:col-span-5 pt-8">
                 <h2 className="mb-4 text-xl font-semibold text-foreground">
                   ロケーション
                 </h2>


### PR DESCRIPTION
## Summary
- Removed top border from map section in property detail page
- Improves visual consistency and cleaner layout

## Changes
- Removed `border-t border-border` classes from map section container
- Changed padding from `pt-4` to `pt-8` for appropriate spacing

## Test Plan
- [x] Verified visual appearance on property detail page
- [x] Confirmed spacing remains appropriate
- [x] Build passes
- [ ] Test on different screen sizes (mobile, tablet, desktop)

Generated with Claude Code