### PR TITLE
feat: add occupancy display to property details

### DIFF
--- a/src/app/listings/[id]/page.tsx
+++ b/src/app/listings/[id]/page.tsx
@@ -24,6 +24,7 @@ import {
   Tv,
   Refrigerator,
   Coffee,
+  Users,
 } from "lucide-react";
 
 const FURNITURE_ICONS: Record<string, typeof BedDouble> = {
@@ -110,6 +111,45 @@ export default async function PropertyDetailPage({
                     .join(" / ")}
                 </p>
               </div>
+
+              {/* Property Info Section */}
+              <section className="py-8 border-b border-border">
+                <h2 className="mb-6 text-xl font-semibold text-foreground">
+                  物件情報
+                </h2>
+
+                <div className="grid grid-cols-2 gap-6">
+                  {/* 間取り */}
+                  <div className="flex items-start gap-3">
+                    <div className="rounded-lg bg-muted p-2">
+                      <Home className="h-5 w-5 text-foreground" />
+                    </div>
+                    <div>
+                      <p className="text-sm text-muted-foreground">間取り</p>
+                      <p className="text-base font-medium text-foreground">
+                        {property.layout}
+                      </p>
+                    </div>
+                  </div>
+
+                  {/* 居住人数 */}
+                  {property.occupancy && (
+                    <div className="flex items-start gap-3">
+                      <div className="rounded-lg bg-muted p-2">
+                        <Users className="h-5 w-5 text-foreground" />
+                      </div>
+                      <div>
+                        <p className="text-sm text-muted-foreground">
+                          居住人数
+                        </p>
+                        <p className="text-base font-medium text-foreground">
+                          {property.occupancy}人
+                        </p>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              </section>
 
               {/* Furniture Section */}
               <section className="py-8 border-b border-border">

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -147,6 +147,7 @@ export interface Property {
     neighborhood?: string // 町名（例：目黒区中目黒）
   }
   layout?: string // 間取り
+  occupancy?: number // 居住人数
   style?: string // e.g., "scandinavian", "industrial", "bohemian", "minimal", "vintage", "modern", etc.
   furniture?: LargeFurnitureType[] // 引き継ぎ対象の大型家具
   status: "draft" | "public"
@@ -221,6 +222,7 @@ export const properties: Property[] = [
     area: "東京",
     location: { lat: 35.6442, lng: 139.6986, neighborhood: "目黒区中目黒" },
     layout: "1K",
+    occupancy: 1,
     style: "bohemian",
     furniture: ["bed", "desk", "storage"],
     condition: "good",
@@ -292,6 +294,7 @@ export const properties: Property[] = [
     area: "東京",
     location: { lat: 35.6580, lng: 139.7016, neighborhood: "渋谷区恵比寿" },
     layout: "1LDK",
+    occupancy: 1,
     style: "industrial",
     furniture: ["bed", "sofa", "desk"],
     condition: "excellent",
@@ -364,6 +367,7 @@ export const properties: Property[] = [
     area: "東京",
     location: { lat: 35.7090, lng: 139.6651, neighborhood: "杉並区高円寺" },
     layout: "1K",
+    occupancy: 1,
     style: "vintage",
     furniture: ["bed", "desk", "storage"],
     condition: "used",


### PR DESCRIPTION
## Summary
- Added occupancy field to property data model
- Display occupancy information in property details page with a dedicated "Property Info Section"
- Shows both layout (間取り) and occupancy (居住人数) with icon-based UI

## Changes
- Added `occupancy?: number` field to Property interface in [src/lib/data.ts](src/lib/data.ts)
- Populated occupancy data (1 person) for 3 existing properties in mock data
- Created new "Property Info Section" in [src/app/listings/[id]/page.tsx](src/app/listings/[id]/page.tsx#L115-L152)
- Added Users icon import from lucide-react for occupancy display
- Styled with consistent layout matching existing sections (bordered, icon-based cards)

## Test Plan
- [x] Build passes successfully
- [x] Linter passes (86 warnings, 0 errors - pre-existing warnings)
- [ ] Verify property details page shows "物件情報" section
- [ ] Verify layout (間取り) displays correctly with Home icon
- [ ] Verify occupancy (居住人数) displays correctly with Users icon
- [ ] Verify section only shows when occupancy data exists
- [ ] Verify responsive layout on mobile/desktop

Generated with Claude Code