### PR TITLE
docs: clarify worktree auto-invoke behavior

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,11 +20,18 @@ npm run lint    # ESLintでコードチェック
 
 ## Git Workflow
 
-**Use `/worktree` skill** for non-trivial implementation tasks (features, fixes, refactoring).
+**CRITICAL: `/worktree` skill auto-invokes** for ANY implementation task.
 
-**Skip worktree for:** Single-line fixes, typos, trivial edits in current branch.
+Claude will automatically invoke `/worktree` as the FIRST action when you request:
+- Feature implementations
+- Bug fixes
+- Refactoring
+- Code modifications
+- UI/UX changes
 
-**Workflow:** `/worktree` → implement → `/commit` → `/pr`
+**Skip worktree only for:** Single-line typo fixes, documentation-only changes.
+
+**Workflow:** `/worktree` (auto) → implement → `/commit` → `/pr`
 
 ## Directory Structure
 


### PR DESCRIPTION
## Summary
- Updated Git Workflow section in CLAUDE.md to clarify that `/worktree` skill auto-invokes for implementation tasks
- Explicitly listed when the skill triggers and when to skip it

## Changes
- Changed header from "Use `/worktree` skill" to "CRITICAL: `/worktree` skill auto-invokes"
- Added explicit list of task types that trigger auto-invoke (feature implementations, bug fixes, refactoring, code modifications, UI/UX changes)
- Clarified skip conditions (single-line typo fixes, documentation-only changes)
- Updated workflow notation to show "(auto)" for auto-invoked worktree step

## Test Plan
- [ ] Verify CLAUDE.md renders correctly in GitHub
- [ ] Verify formatting and clarity of updated section

Generated with Claude Code