### PR TITLE
docs: add local branch cleanup step after PR merge

### DIFF
--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -49,6 +49,12 @@ When creating PRs:
 5. Push with `-u` flag if new branch
 6. Verify PR contains only related changes
 7. **IMMEDIATELY merge PR with `gh pr merge <number> --squash --delete-branch`**
+8. **Switch back to main and delete local branch:**
+   ```bash
+   git checkout main
+   git pull origin main
+   git branch -D <feature-branch-name>
+   ```
 
 ## Feature Implementation Workflow
 


### PR DESCRIPTION
## Summary
- Added step 8 to PR workflow for cleaning up local feature branches after merge
- Shows exact commands: switch to main, pull, delete local branch

## Changes
- Added step 8 with code block showing:
  - `git checkout main`
  - `git pull origin main`
  - `git branch -D <feature-branch-name>`

## Test Plan
- [ ] Verify .claude/rules/git-workflow.md renders correctly
- [ ] Verify code block formatting

Generated with Claude Code