### PR TITLE
fix: add viewing_completed filter to inquiry list

### DIFF
--- a/src/components/admin/inquiry-list.tsx
+++ b/src/components/admin/inquiry-list.tsx
@@ -67,6 +67,14 @@ export function InquiryList({ inquiries }: InquiryListProps) {
         >
           完了 ({inquiries.filter((i) => i.status === "completed").length})
         </Button>
+        <Button
+          variant={filterStatus === "viewing_completed" ? "default" : "outline"}
+          size="sm"
+          onClick={() => setFilterStatus("viewing_completed")}
+          className="rounded-full"
+        >
+          内見完了 ({inquiries.filter((i) => i.status === "viewing_completed").length})
+        </Button>
       </div>
 
       {/* Inquiry Cards */}


### PR DESCRIPTION
## Summary
- Added missing filter button for `viewing_completed` status in admin inquiry list

## Changes
- Added filter button UI for "内見完了" (viewing completed) status
- The status type was already defined but the filter button was missing from the UI

## Test plan
- [ ] Verify the new filter button appears in the admin inquiry list
- [ ] Click the filter button and verify it filters inquiries with `viewing_completed` status
- [ ] Verify the count displays correctly

Generated with [Claude Code](https://claude.com/claude-code)