### PR TITLE
refactor: unify landlordConsent type to LandlordConsent object

### DIFF
--- a/src/components/admin/host-listing-list.tsx
+++ b/src/components/admin/host-listing-list.tsx
@@ -144,7 +144,7 @@ export function HostListingList({ listings }: HostListingListProps) {
 
                 <div className="rounded-lg bg-green-50 p-4">
                   <div className="flex items-center gap-2 text-sm font-semibold text-green-800">
-                    {listing.landlordConsent ? "大家さんの承諾済み" : "大家さんの承諾未確認"}
+                    {listing.landlordConsent.hasLandlordConsent ? "大家さんの承諾済み" : "大家さんの承諾未確認"}
                   </div>
                 </div>
 

--- a/src/components/seller-form.tsx
+++ b/src/components/seller-form.tsx
@@ -33,6 +33,7 @@ export function SellerForm() {
     // Log the seller listing data
     console.log("Seller listing submitted:", {
       ...formData,
+      landlordConsent: { hasLandlordConsent: formData.landlordConsent },
       submittedAt: new Date().toISOString(),
     })
 

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -78,7 +78,7 @@ export interface SellerListing {
   moveOutDate: string
   furnitureDescription: string
   whyListing: string
-  landlordConsent: boolean
+  landlordConsent: LandlordConsent
   submittedAt: string
   updatedAt: string
   notes?: string // 運営メモ
@@ -2186,7 +2186,7 @@ export const hostListings: SellerListing[] = [
     moveOutDate: "2026-04-30",
     furnitureDescription: "北欧家具一式、ヴィンテージのダイニングテーブル、観葉植物多数",
     whyListing: "海外転勤が決まり、大切にしてきた家具を次の人に引き継ぎたいです。",
-    landlordConsent: true,
+    landlordConsent: { hasLandlordConsent: true },
     submittedAt: "2026-01-16T11:00:00Z",
     updatedAt: "2026-01-16T11:00:00Z",
   },
@@ -2200,7 +2200,7 @@ export const hostListings: SellerListing[] = [
     moveOutDate: "2026-03-31",
     furnitureDescription: "手作りの本棚、アンティーク照明、ベッドフレーム",
     whyListing: "引っ越しすることになり、この部屋での思い出を大切にしてくれる人に譲りたいです。",
-    landlordConsent: true,
+    landlordConsent: { hasLandlordConsent: true },
     submittedAt: "2026-01-08T14:20:00Z",
     updatedAt: "2026-01-10T10:00:00Z",
     notes: "ヒアリング完了。掲載準備中。",


### PR DESCRIPTION
## Summary
- Unified `landlordConsent` type from `boolean` to `LandlordConsent` object across the codebase

## Changes
- Updated `SellerListing` interface to use `LandlordConsent` type instead of `boolean`
- Updated mock data to use object format: `{ hasLandlordConsent: true }`
- Updated seller form to convert boolean checkbox value to `LandlordConsent` object on submit
- Updated host listing list component to access `hasLandlordConsent` property

## Reason
- Provides type consistency with `DraftProperty.landlordConsent` which already used `LandlordConsent` type
- Better extensibility for future landlord consent-related fields
- Clearer type definition

## Test plan
- [ ] Verify seller form submission works correctly
- [ ] Verify host listing list displays landlord consent status correctly
- [ ] Verify no TypeScript errors

Generated with [Claude Code](https://claude.com/claude-code)