### PR TITLE
fix: update Inquiry status from 4 to 8 stages per requirements

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -8,7 +8,7 @@ import { Check, Clock, Calendar, Home, ArrowRight } from "lucide-react"
 
 const inquirySteps = [
   { id: "pending", label: "申し込み", icon: Check },
-  { id: "decided", label: "引き継ぎ決定", icon: Calendar },
+  { id: "contract_in_progress", label: "引き継ぎ決定", icon: Calendar },
   { id: "completed", label: "引き継ぎ完了", icon: Home },
 ]
 
@@ -22,11 +22,17 @@ export default function DashboardPage() {
   const getStepIndex = (status: string) => {
     switch (status) {
       case "pending":
+      case "reviewing":
+      case "approved":
+      case "viewing_scheduled":
         return 0
-      case "decided":
+      case "contract_in_progress":
         return 1
       case "completed":
         return 2
+      case "rejected":
+      case "cancelled":
+        return 0
       default:
         return 0
     }
@@ -35,11 +41,21 @@ export default function DashboardPage() {
   const getNextAction = (status: string) => {
     switch (status) {
       case "pending":
-        return "内見の日程調整のご連絡をお待ちください"
-      case "decided":
+        return "前の住人からのご連絡をお待ちください"
+      case "reviewing":
+        return "前の住人が内容を確認中です"
+      case "approved":
+        return "内見の日程調整をお待ちください"
+      case "viewing_scheduled":
+        return "内見予定日が確定しました"
+      case "contract_in_progress":
         return "引き継ぎの準備を進めましょう"
       case "completed":
         return "引き継ぎが完了しました"
+      case "rejected":
+        return "申し訳ございません。今回はお断りとなりました"
+      case "cancelled":
+        return "申し込みがキャンセルされました"
       default:
         return "お待ちください"
     }
@@ -150,17 +166,21 @@ export default function DashboardPage() {
 
                     {/* 次のアクション */}
                     <div className={`rounded-lg p-4 ${
-                      inquiry.status === "pending"
+                      inquiry.status === "pending" || inquiry.status === "reviewing"
                         ? "bg-amber-50 border border-amber-200"
                         : inquiry.status === "completed"
                         ? "bg-green-50 border border-green-200"
-                        : "bg-blue-50"
+                        : inquiry.status === "rejected" || inquiry.status === "cancelled"
+                        ? "bg-red-50 border border-red-200"
+                        : "bg-blue-50 border border-blue-200"
                     }`}>
                       <p className={`flex items-center gap-2 text-sm font-semibold ${
-                        inquiry.status === "pending"
+                        inquiry.status === "pending" || inquiry.status === "reviewing"
                           ? "text-amber-900"
                           : inquiry.status === "completed"
                           ? "text-green-900"
+                          : inquiry.status === "rejected" || inquiry.status === "cancelled"
+                          ? "text-red-900"
                           : "text-blue-900"
                       }`}>
                         {inquiry.status === "pending" ? (

--- a/src/components/admin/inquiry-list.tsx
+++ b/src/components/admin/inquiry-list.tsx
@@ -13,16 +13,24 @@ interface InquiryListProps {
 
 const statusColors: Record<Inquiry["status"], string> = {
   pending: "bg-yellow-100 text-yellow-800 border-yellow-200",
-  decided: "bg-blue-100 text-blue-800 border-blue-200",
+  reviewing: "bg-orange-100 text-orange-800 border-orange-200",
+  approved: "bg-blue-100 text-blue-800 border-blue-200",
+  viewing_scheduled: "bg-purple-100 text-purple-800 border-purple-200",
+  contract_in_progress: "bg-indigo-100 text-indigo-800 border-indigo-200",
   completed: "bg-green-100 text-green-800 border-green-200",
-  viewing_completed: "bg-purple-100 text-purple-800 border-purple-200",
+  rejected: "bg-red-100 text-red-800 border-red-200",
+  cancelled: "bg-gray-100 text-gray-800 border-gray-200",
 }
 
 const statusLabels: Record<Inquiry["status"], string> = {
   pending: "新規",
-  decided: "引き継ぎ決定",
+  reviewing: "確認中",
+  approved: "承認済み",
+  viewing_scheduled: "内見予定",
+  contract_in_progress: "契約手続き中",
   completed: "完了",
-  viewing_completed: "内見完了",
+  rejected: "お断り",
+  cancelled: "キャンセル",
 }
 
 export function InquiryList({ inquiries }: InquiryListProps) {
@@ -52,12 +60,36 @@ export function InquiryList({ inquiries }: InquiryListProps) {
           新規 ({inquiries.filter((i) => i.status === "pending").length})
         </Button>
         <Button
-          variant={filterStatus === "decided" ? "default" : "outline"}
+          variant={filterStatus === "reviewing" ? "default" : "outline"}
           size="sm"
-          onClick={() => setFilterStatus("decided")}
+          onClick={() => setFilterStatus("reviewing")}
           className="rounded-full"
         >
-          引き継ぎ決定 ({inquiries.filter((i) => i.status === "decided").length})
+          確認中 ({inquiries.filter((i) => i.status === "reviewing").length})
+        </Button>
+        <Button
+          variant={filterStatus === "approved" ? "default" : "outline"}
+          size="sm"
+          onClick={() => setFilterStatus("approved")}
+          className="rounded-full"
+        >
+          承認済み ({inquiries.filter((i) => i.status === "approved").length})
+        </Button>
+        <Button
+          variant={filterStatus === "viewing_scheduled" ? "default" : "outline"}
+          size="sm"
+          onClick={() => setFilterStatus("viewing_scheduled")}
+          className="rounded-full"
+        >
+          内見予定 ({inquiries.filter((i) => i.status === "viewing_scheduled").length})
+        </Button>
+        <Button
+          variant={filterStatus === "contract_in_progress" ? "default" : "outline"}
+          size="sm"
+          onClick={() => setFilterStatus("contract_in_progress")}
+          className="rounded-full"
+        >
+          契約手続き中 ({inquiries.filter((i) => i.status === "contract_in_progress").length})
         </Button>
         <Button
           variant={filterStatus === "completed" ? "default" : "outline"}
@@ -68,12 +100,20 @@ export function InquiryList({ inquiries }: InquiryListProps) {
           完了 ({inquiries.filter((i) => i.status === "completed").length})
         </Button>
         <Button
-          variant={filterStatus === "viewing_completed" ? "default" : "outline"}
+          variant={filterStatus === "rejected" ? "default" : "outline"}
           size="sm"
-          onClick={() => setFilterStatus("viewing_completed")}
+          onClick={() => setFilterStatus("rejected")}
           className="rounded-full"
         >
-          内見完了 ({inquiries.filter((i) => i.status === "viewing_completed").length})
+          お断り ({inquiries.filter((i) => i.status === "rejected").length})
+        </Button>
+        <Button
+          variant={filterStatus === "cancelled" ? "default" : "outline"}
+          size="sm"
+          onClick={() => setFilterStatus("cancelled")}
+          className="rounded-full"
+        >
+          キャンセル ({inquiries.filter((i) => i.status === "cancelled").length})
         </Button>
       </div>
 

--- a/src/components/viewing-confirmation.tsx
+++ b/src/components/viewing-confirmation.tsx
@@ -46,7 +46,7 @@ export function ViewingConfirmation({
     const now = new Date().toISOString();
     const updatedInquiry: Inquiry = {
       ...inquiry,
-      status: bothConfirmed ? "viewing_completed" : inquiry.status,
+      status: bothConfirmed ? "approved" : inquiry.status,
       viewingConfirmation: {
         ...confirmation,
         ...(userRole === "host"
@@ -60,7 +60,7 @@ export function ViewingConfirmation({
       (userRole === "host" && isApplicantConfirmed) ||
       (userRole === "applicant" && isHostConfirmed)
     ) {
-      updatedInquiry.status = "viewing_completed";
+      updatedInquiry.status = "approved";
     }
 
     setTimeout(() => {

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -55,7 +55,7 @@ export interface Inquiry {
   id: string
   propertyId: string
   propertyTitle: string
-  status: "pending" | "decided" | "completed" | "viewing_completed"
+  status: "pending" | "reviewing" | "approved" | "viewing_scheduled" | "contract_in_progress" | "completed" | "rejected" | "cancelled"
   applicantName: string
   applicantEmail: string
   reason: string // 興味を持った理由
@@ -2129,7 +2129,7 @@ export const inquiries: Inquiry[] = [
     id: "inq_002",
     propertyId: "2",
     propertyTitle: "DJ/プロデューサーの音楽制作空間",
-    status: "decided",
+    status: "contract_in_progress",
     applicantName: "佐藤 太郎",
     applicantEmail: "sato@example.com",
     reason: "DJとして活動しており、この防音環境と機材に魅力を感じました。レコードコレクションを引き継げるのも嬉しいです。",
@@ -2141,7 +2141,7 @@ export const inquiries: Inquiry[] = [
     id: "inq_003",
     propertyId: "1",
     propertyTitle: "アートと植物に囲まれたワンルーム",
-    status: "pending",
+    status: "reviewing",
     applicantName: "鈴木 美咲",
     applicantEmail: "suzuki@example.com",
     reason: "グラフィックデザイナーとして、こういう創作意欲が湧く空間を探していました。",
@@ -2165,12 +2165,49 @@ export const inquiries: Inquiry[] = [
     id: "inq_005",
     propertyId: "4",
     propertyTitle: "ヴィンテージ家具のある部屋",
-    status: "pending",
+    status: "approved",
     applicantName: "田中 花子",
     applicantEmail: "tanaka@example.com",
     reason: "ヴィンテージ家具に興味がありました。",
     submittedAt: "2026-01-08T09:00:00Z",
     updatedAt: "2026-01-09T15:00:00Z",
+    notes: "申し込み承認。内見日程調整待ち。",
+  },
+  {
+    id: "inq_006",
+    propertyId: "2",
+    propertyTitle: "DJ/プロデューサーの音楽制作空間",
+    status: "viewing_scheduled",
+    applicantName: "高橋 健太",
+    applicantEmail: "takahashi@example.com",
+    reason: "音楽制作に集中できる環境を探していました。",
+    submittedAt: "2026-01-13T14:00:00Z",
+    updatedAt: "2026-01-14T10:00:00Z",
+    notes: "内見予定: 2026年1月20日 14:00",
+  },
+  {
+    id: "inq_007",
+    propertyId: "3",
+    propertyTitle: "北欧ミニマルな1DK",
+    status: "rejected",
+    applicantName: "伊藤 真理",
+    applicantEmail: "ito@example.com",
+    reason: "シンプルな暮らしをしたいと思いました。",
+    submittedAt: "2026-01-05T11:00:00Z",
+    updatedAt: "2026-01-07T09:00:00Z",
+    notes: "前の住人の都合によりお断り。",
+  },
+  {
+    id: "inq_008",
+    propertyId: "1",
+    propertyTitle: "アートと植物に囲まれたワンルーム",
+    status: "cancelled",
+    applicantName: "渡辺 隆",
+    applicantEmail: "watanabe@example.com",
+    reason: "アート作品に囲まれた生活に憧れました。",
+    submittedAt: "2026-01-06T16:00:00Z",
+    updatedAt: "2026-01-08T14:00:00Z",
+    notes: "申込者都合によりキャンセル。",
   },
 ]
 


### PR DESCRIPTION
## Summary

要件定義書に記載されている8段階のInquiryステータスに合わせて実装を修正しました。

### 変更内容

**修正前（4段階）:**
- `pending`（新規）
- `decided`（引き継ぎ決定）
- `completed`（完了）
- `viewing_completed`（内見完了）

**修正後（8段階）:**
- `pending`（新規）
- `reviewing`（確認中）
- `approved`（承認済み）
- `viewing_scheduled`（内見予定）
- `contract_in_progress`（契約手続き中）
- `completed`（完了）
- `rejected`（お断り）
- `cancelled`（キャンセル）

### 影響範囲

- [src/lib/data.ts](src/lib/data.ts#L58) - Inquiry型の定義を更新
- [src/components/admin/inquiry-list.tsx](src/components/admin/inquiry-list.tsx) - 管理画面の8段階フィルター対応
- [src/components/viewing-confirmation.tsx](src/components/viewing-confirmation.tsx) - `viewing_completed` → `approved` に変更
- [src/app/dashboard/page.tsx](src/app/dashboard/page.tsx) - ユーザー向けダッシュボードで8段階→3ステップのマッピング

### モックデータ

8段階すべてのステータスをカバーするサンプルデータを追加しました。

## Test plan

- [x] TypeScriptビルドが成功することを確認
- [ ] 管理画面で8つのフィルターボタンが正しく動作することを確認
- [ ] ダッシュボードで各ステータスが適切な進捗ステップにマッピングされることを確認
- [ ] 内見確認後のステータス更新が正しく動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)