### PR TITLE
feat: add database configuration files

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,32 @@
+# Database Configuration (Neon PostgreSQL)
+# Get this from Neon dashboard: https://neon.tech
+DATABASE_URL="postgresql://[user]:[password]@[host]/[db]?sslmode=require"
+
+# NextAuth.js Configuration
+# Generate a secret: openssl rand -base64 32
+NEXTAUTH_URL="http://localhost:3000"
+NEXTAUTH_SECRET="your-secret-key-here"
+
+# OAuth Providers (Optional)
+# Google: https://console.cloud.google.com/
+GOOGLE_CLIENT_ID=""
+GOOGLE_CLIENT_SECRET=""
+
+# Apple (Optional)
+APPLE_CLIENT_ID=""
+APPLE_CLIENT_SECRET=""
+
+# AWS S3 Configuration (Optional - for image storage)
+# AWS Console: https://console.aws.amazon.com/
+AWS_ACCESS_KEY_ID=""
+AWS_SECRET_ACCESS_KEY=""
+AWS_REGION="ap-northeast-1"
+AWS_S3_BUCKET_NAME="tsumugi-images"
+
+# Email Provider (Optional - for notifications)
+# Resend: https://resend.com/
+RESEND_API_KEY=""
+EMAIL_FROM="noreply@tsumugi.example.com"
+
+# Environment
+NODE_ENV="development"

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "drizzle-kit";
+
+export default defineConfig({
+  schema: "./src/db/schema/index.ts",
+  out: "./src/db/migrations",
+  dialect: "postgresql",
+  dbCredentials: {
+    url: process.env.DATABASE_URL!,
+  },
+  verbose: true,
+  strict: true,
+});


### PR DESCRIPTION
## Summary
- Added environment variable template for database and external services
- Added Drizzle ORM configuration for schema management
- Configured integration points for PostgreSQL, authentication, storage, and email

## Changes
- Created `.env.example` with placeholders for:
  - Neon PostgreSQL connection string
  - NextAuth.js secret and URL
  - Google and Apple OAuth credentials (optional)
  - AWS S3 credentials for image storage (optional)
  - Resend API key for email notifications (optional)
- Created `drizzle.config.ts` for database schema and migration management
- Configured schema path, migration output directory, and database driver

## Test Plan
- [ ] Copy `.env.example` to `.env` and verify format is correct
- [ ] Confirm Drizzle config points to correct schema files
- [ ] Verify environment variables load properly in development
- [ ] Check that all placeholder values are clearly marked

Generated with Claude Code