### PR TITLE
feat: add inquiry and property database schemas

### DIFF
--- a/src/db/schema/inquiries.ts
+++ b/src/db/schema/inquiries.ts
@@ -1,0 +1,47 @@
+import { pgTable, uuid, varchar, text, timestamp, jsonb, index } from "drizzle-orm/pg-core";
+import { properties } from "./properties";
+import { users } from "./users";
+
+export const inquiries = pgTable("inquiries", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  propertyId: uuid("property_id").notNull().references(() => properties.id, { onDelete: "cascade" }),
+  userId: uuid("user_id").references(() => users.id, { onDelete: "set null" }),
+
+  // Property Snapshot
+  propertyTitle: varchar("property_title", { length: 500 }).notNull(),
+
+  // Status Management
+  status: varchar("status", { length: 50 }).default("pending").notNull(),
+  // 'pending' | 'reviewing' | 'approved' | 'viewing_scheduled'
+  // | 'contract_in_progress' | 'completed' | 'rejected' | 'cancelled'
+
+  // Applicant Info
+  applicantName: varchar("applicant_name", { length: 255 }).notNull(),
+  applicantEmail: varchar("applicant_email", { length: 255 }).notNull(),
+
+  // Content
+  reason: text("reason").notNull(),
+  questions: text("questions"),
+
+  // Viewing Confirmation (JSONB)
+  viewingConfirmation: jsonb("viewing_confirmation").$type<{
+    hostConfirmed?: boolean;
+    hostConfirmedAt?: string;
+    applicantConfirmed?: boolean;
+    applicantConfirmedAt?: string;
+  }>().default({}),
+
+  // Admin Notes
+  notes: text("notes"),
+
+  // Timestamps
+  submittedAt: timestamp("submitted_at", { withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
+}, (table) => {
+  return {
+    propertyIdIdx: index("idx_inquiries_property_id").on(table.propertyId),
+    userIdIdx: index("idx_inquiries_user_id").on(table.userId),
+    statusIdx: index("idx_inquiries_status").on(table.status),
+    submittedAtIdx: index("idx_inquiries_submitted_at").on(table.submittedAt),
+  };
+});

--- a/src/db/schema/properties.ts
+++ b/src/db/schema/properties.ts
@@ -1,0 +1,87 @@
+import { pgTable, uuid, varchar, text, integer, timestamp, jsonb, decimal, index } from "drizzle-orm/pg-core";
+import { users } from "./users";
+
+export const properties = pgTable("properties", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  userId: uuid("user_id").notNull().references(() => users.id, { onDelete: "cascade" }),
+
+  // Basic Info
+  title: varchar("title", { length: 500 }).notNull(),
+  summary: text("summary"),
+  images: text("images").array().notNull(), // Array of S3 URLs
+  status: varchar("status", { length: 20 }).default("draft").notNull(), // 'draft' | 'public'
+
+  // Pricing
+  handoverFee: integer("handover_fee"),
+  rent: integer("rent"),
+  managementFee: integer("management_fee"),
+  deposit: decimal("deposit", { precision: 3, scale: 1 }), // Months
+  keyMoney: decimal("key_money", { precision: 3, scale: 1 }), // Months
+
+  // Location
+  area: varchar("area", { length: 100 }),
+  lat: decimal("lat", { precision: 10, scale: 7 }),
+  lng: decimal("lng", { precision: 10, scale: 7 }),
+  neighborhood: varchar("neighborhood", { length: 255 }),
+
+  // Property Details
+  layout: varchar("layout", { length: 50 }),
+  occupancy: integer("occupancy"),
+  style: varchar("style", { length: 50 }),
+  furniture: text("furniture").array(), // Array of furniture types
+  condition: varchar("condition", { length: 20 }), // 'excellent' | 'good' | 'used'
+
+  // Detailed Descriptions
+  furnitureDescription: text("furniture_description"),
+  story: text("story"),
+  conditions: text("conditions"),
+
+  // Handover Details (JSONB for nested structure)
+  handoverDetails: jsonb("handover_details").$type<{
+    included?: string[];
+    notIncluded?: string[];
+    viewingAvailableFrom?: string;
+    moveInAvailableFrom?: string;
+  }>(),
+
+  // FAQ
+  faq: jsonb("faq").$type<Array<{
+    question: string;
+    answer: string;
+  }>>(),
+
+  // Host Profile (denormalized for performance)
+  handoverHost: jsonb("handover_host").$type<{
+    name: string;
+    occupation: string;
+    bio: string;
+    avatar?: string;
+    whyChoseThis?: Array<{ reason: string; image?: string }>;
+    messageToNext?: string;
+    socialLinks?: {
+      instagram?: string;
+      twitter?: string;
+      website?: string;
+      youtube?: string;
+      tiktok?: string;
+    };
+  }>(),
+
+  // Internal Management
+  issueRecord: jsonb("issue_record").$type<Array<{
+    issue: string;
+    reportedAt: string;
+  }>>().default([]),
+
+  // Timestamps
+  createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
+  publishedAt: timestamp("published_at", { withTimezone: true }),
+}, (table) => {
+  return {
+    statusIdx: index("idx_properties_status").on(table.status),
+    userIdIdx: index("idx_properties_user_id").on(table.userId),
+    areaIdx: index("idx_properties_area").on(table.area),
+    createdAtIdx: index("idx_properties_created_at").on(table.createdAt),
+  };
+});


### PR DESCRIPTION
## Summary
- Added database schemas for property listings and handover applications
- Implemented 8-stage inquiry workflow with viewing confirmations
- Created comprehensive property schema with seller profiles and handover details
- Established foreign key relationships between inquiries and properties

## Changes
- **src/db/schema/inquiries.ts**: Handover applications table
  - 8-stage status workflow tracking
  - Applicant information and inquiry details
  - Viewing confirmation (mutual host/applicant confirmation)
  - Foreign key to properties table
  - Timestamps for submission and updates
  
- **src/db/schema/properties.ts**: Property listings table
  - Property details (title, images, pricing, location)
  - Handover metadata (fees, dates, included items)
  - Seller profile (occupation, bio, social links, reasons for choosing)
  - Draft/public status management
  - Timestamps for creation, updates, and publishing

## Test Plan
- [ ] Run `npx drizzle-kit generate` to create migrations
- [ ] Verify foreign key constraints work correctly
- [ ] Test that all status enum values are valid
- [ ] Confirm JSON fields (images, furniture) serialize properly
- [ ] Validate timestamp fields auto-populate correctly

Generated with Claude Code