### PR TITLE
fix: update database schema for NextAuth compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "my-v0-project",
       "version": "0.1.0",
       "dependencies": {
+        "@auth/core": "^0.41.0",
+        "@auth/drizzle-adapter": "^1.11.1",
         "@hookform/resolvers": "^3.10.0",
         "@neondatabase/serverless": "^1.0.2",
         "@radix-ui/react-accordion": "1.2.2",
@@ -108,6 +110,44 @@
         "@simplewebauthn/browser": "^9.0.1",
         "@simplewebauthn/server": "^9.0.2",
         "nodemailer": "^6.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@simplewebauthn/browser": {
+          "optional": true
+        },
+        "@simplewebauthn/server": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@auth/drizzle-adapter": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@auth/drizzle-adapter/-/drizzle-adapter-1.11.1.tgz",
+      "integrity": "sha512-cQTvDZqsyF7RPhDm/B6SvqdVP9EzQhy3oM4Muu7fjjmSYFLbSR203E6dH631ZHSKDn2b4WZkfMnjPDzRsPSAeA==",
+      "license": "ISC",
+      "dependencies": {
+        "@auth/core": "0.41.1"
+      }
+    },
+    "node_modules/@auth/drizzle-adapter/node_modules/@auth/core": {
+      "version": "0.41.1",
+      "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.41.1.tgz",
+      "integrity": "sha512-t9cJ2zNYAdWMacGRMT6+r4xr1uybIdmYa49calBPeTqwgAFPV/88ac9TEvCR85pvATiSPt8VaNf+Gt24JIT/uw==",
+      "license": "ISC",
+      "dependencies": {
+        "@panva/hkdf": "^1.2.1",
+        "jose": "^6.0.6",
+        "oauth4webapi": "^3.3.0",
+        "preact": "10.24.3",
+        "preact-render-to-string": "6.5.11"
+      },
+      "peerDependencies": {
+        "@simplewebauthn/browser": "^9.0.1",
+        "@simplewebauthn/server": "^9.0.2",
+        "nodemailer": "^7.0.7"
       },
       "peerDependenciesMeta": {
         "@simplewebauthn/browser": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "worktree:prune": "git worktree prune"
   },
   "dependencies": {
+    "@auth/core": "^0.41.0",
+    "@auth/drizzle-adapter": "^1.11.1",
     "@hookform/resolvers": "^3.10.0",
     "@neondatabase/serverless": "^1.0.2",
     "@radix-ui/react-accordion": "1.2.2",

--- a/src/db/schema/sessions.ts
+++ b/src/db/schema/sessions.ts
@@ -3,39 +3,32 @@ import { users } from "./users";
 
 // Sessions table for NextAuth.js
 export const sessions = pgTable("sessions", {
-  id: uuid("id").primaryKey().defaultRandom(),
+  sessionToken: varchar("session_token", { length: 255 }).primaryKey(),
   userId: uuid("user_id").notNull().references(() => users.id, { onDelete: "cascade" }),
-  sessionToken: varchar("session_token", { length: 255 }).unique().notNull(),
   expires: timestamp("expires", { withTimezone: true }).notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
 }, (table) => {
   return {
     userIdIdx: index("idx_sessions_user_id").on(table.userId),
-    expiresIdx: index("idx_sessions_expires").on(table.expires),
   };
 });
 
-// Accounts table for OAuth providers
+// Accounts table for OAuth providers (NextAuth.js compatible)
 export const accounts = pgTable("accounts", {
-  id: uuid("id").primaryKey().defaultRandom(),
   userId: uuid("user_id").notNull().references(() => users.id, { onDelete: "cascade" }),
-  type: varchar("type", { length: 50 }).notNull(), // 'oauth' | 'email'
-  provider: varchar("provider", { length: 50 }).notNull(), // 'google' | 'apple' | 'email'
+  type: varchar("type", { length: 50 }).notNull(),
+  provider: varchar("provider", { length: 50 }).notNull(),
   providerAccountId: varchar("provider_account_id", { length: 255 }).notNull(),
-
-  // OAuth tokens
-  refreshToken: text("refresh_token"),
-  accessToken: text("access_token"),
-  expiresAt: integer("expires_at"),
-  tokenType: varchar("token_type", { length: 50 }),
+  refresh_token: text("refresh_token"),
+  access_token: text("access_token"),
+  expires_at: integer("expires_at"),
+  token_type: varchar("token_type", { length: 50 }),
   scope: text("scope"),
-  idToken: text("id_token"),
-
-  createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+  id_token: text("id_token"),
+  session_state: text("session_state"),
 }, (table) => {
   return {
+    pk: primaryKey({ columns: [table.provider, table.providerAccountId] }),
     userIdIdx: index("idx_accounts_user_id").on(table.userId),
-    providerAccountIdIdx: index("idx_accounts_provider_account_id").on(table.provider, table.providerAccountId),
   };
 });
 

--- a/src/db/schema/users.ts
+++ b/src/db/schema/users.ts
@@ -5,14 +5,14 @@ export const users = pgTable("users", {
   email: varchar("email", { length: 255 }).unique().notNull(),
   name: varchar("name", { length: 255 }).notNull(),
   phone: varchar("phone", { length: 50 }),
-  avatarUrl: text("avatar_url"),
+  image: text("image"), // NextAuth uses 'image' field
+  emailVerified: timestamp("email_verified", { withTimezone: true }), // NextAuth uses timestamp
   createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
   updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
 
   // Authentication
   passwordHash: text("password_hash"),
   authProvider: varchar("auth_provider", { length: 50 }).default("email"),
-  emailVerified: boolean("email_verified").default(false),
 
   // Roles
   isSeller: boolean("is_seller").default(false).notNull(),


### PR DESCRIPTION
## Summary
- Updated database schema to be fully compatible with NextAuth v5 and DrizzleAdapter
- Aligned field names and types with NextAuth standards
- Added missing @auth/drizzle-adapter dependency
- Simplified tables by removing unnecessary fields

## Changes

**Users table:**
- Renamed `avatarUrl` → `image` (NextAuth standard)
- Changed `emailVerified` from `boolean` to `timestamp` (NextAuth uses timestamp for verification date)

**Sessions table:**
- Made `sessionToken` the primary key (NextAuth standard)
- Removed separate `id` field
- Removed `createdAt` (not required)

**Accounts table:**
- Removed `id` field, using composite PK: `(provider, providerAccountId)`
- Updated field names to match DrizzleAdapter expectations (snake_case in TypeScript):
  - `refreshToken` → `refresh_token`
  - `accessToken` → `access_token`
  - `expiresAt` → `expires_at`
  - `tokenType` → `token_type`
  - `idToken` → `id_token`
- Added `session_state` field for OAuth compatibility
- Removed `createdAt` (not required)

**Dependencies:**
- Added `@auth/drizzle-adapter` for NextAuth database integration

## Test Plan
- [ ] Run `npx drizzle-kit generate` to create new migrations
- [ ] Verify TypeScript compilation passes
- [ ] Check NextAuth adapter compatibility
- [ ] Confirm no breaking changes to existing queries

Generated with Claude Code