### PR TITLE
feat: add NextAuth core configuration

### DIFF
--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,3 @@
+import { handlers } from "@/lib/auth";
+
+export const { GET, POST } = handlers;

--- a/src/lib/auth-provider.tsx
+++ b/src/lib/auth-provider.tsx
@@ -1,0 +1,8 @@
+"use client";
+
+import { SessionProvider } from "next-auth/react";
+import type { ReactNode } from "react";
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  return <SessionProvider>{children}</SessionProvider>;
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,144 @@
+import NextAuth, { type DefaultSession } from "next-auth";
+import { DrizzleAdapter } from "@auth/drizzle-adapter";
+import CredentialsProvider from "next-auth/providers/credentials";
+import GoogleProvider from "next-auth/providers/google";
+import { db } from "@/db";
+import { users, accounts, sessions, verificationTokens } from "@/db/schema";
+import { compare } from "bcryptjs";
+import { eq } from "drizzle-orm";
+
+// Extend NextAuth types
+declare module "next-auth" {
+  interface Session extends DefaultSession {
+    user: {
+      id: string;
+      isSeller: boolean;
+      isAdmin: boolean;
+    } & DefaultSession["user"];
+  }
+
+  interface User {
+    isSeller: boolean;
+    isAdmin: boolean;
+  }
+}
+
+export const { handlers, auth, signIn, signOut } = NextAuth({
+  adapter: DrizzleAdapter(db, {
+    usersTable: users,
+    accountsTable: accounts,
+    sessionsTable: sessions,
+    verificationTokensTable: verificationTokens,
+  }),
+
+  providers: [
+    CredentialsProvider({
+      name: "Email",
+      credentials: {
+        email: { label: "Email", type: "email" },
+        password: { label: "Password", type: "password" },
+      },
+      async authorize(credentials) {
+        if (!credentials?.email || !credentials?.password) {
+          throw new Error("メールアドレスとパスワードを入力してください");
+        }
+
+        const email = credentials.email as string;
+        const password = credentials.password as string;
+
+        // Find user by email
+        const user = await db.query.users.findFirst({
+          where: eq(users.email, email),
+        });
+
+        if (!user || !user.passwordHash) {
+          throw new Error("メールアドレスまたはパスワードが正しくありません");
+        }
+
+        // Verify password
+        const isValid = await compare(password, user.passwordHash);
+
+        if (!isValid) {
+          throw new Error("メールアドレスまたはパスワードが正しくありません");
+        }
+
+        return {
+          id: user.id,
+          email: user.email,
+          name: user.name,
+          image: user.avatarUrl,
+          isSeller: user.isSeller,
+          isAdmin: user.isAdmin || false,
+        };
+      },
+    }),
+
+    // Google OAuth provider (optional)
+    ...(process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET
+      ? [
+          GoogleProvider({
+            clientId: process.env.GOOGLE_CLIENT_ID,
+            clientSecret: process.env.GOOGLE_CLIENT_SECRET,
+          }),
+        ]
+      : []),
+  ],
+
+  session: {
+    strategy: "database",
+    maxAge: 30 * 24 * 60 * 60, // 30 days
+    updateAge: 24 * 60 * 60, // 24 hours
+  },
+
+  pages: {
+    signIn: "/", // Redirect to home page for sign in
+    error: "/", // Error page
+  },
+
+  callbacks: {
+    async session({ session, user }) {
+      if (session.user) {
+        session.user.id = user.id;
+
+        // Fetch latest user data to get isSeller and isAdmin
+        const dbUser = await db.query.users.findFirst({
+          where: eq(users.id, user.id),
+          columns: {
+            isSeller: true,
+            isAdmin: true,
+          },
+        });
+
+        session.user.isSeller = dbUser?.isSeller || false;
+        session.user.isAdmin = dbUser?.isAdmin || false;
+      }
+      return session;
+    },
+
+    async signIn({ user, account }) {
+      // For OAuth providers, update user info if needed
+      if (account?.provider === "google" && user.email) {
+        const existingUser = await db.query.users.findFirst({
+          where: eq(users.email, user.email),
+        });
+
+        if (existingUser) {
+          // Update user's OAuth account if not already linked
+          return true;
+        }
+      }
+      return true;
+    },
+  },
+
+  events: {
+    async signIn({ user }) {
+      console.log(`User signed in: ${user.email}`);
+    },
+    async signOut() {
+      console.log("User signed out");
+    },
+  },
+
+  debug: process.env.NODE_ENV === "development",
+});


### PR DESCRIPTION
## Summary
- Implemented NextAuth v5 authentication with database persistence via Drizzle ORM
- Added email/password authentication with bcryptjs hashing
- Configured optional Google OAuth provider
- Extended session with custom user fields (isSeller, isAdmin)
- Provided client-side SessionProvider wrapper

## Changes

**src/lib/auth.ts** (144 lines):
- NextAuth configuration with DrizzleAdapter
- Custom TypeScript declarations for extended User and Session types
- Credentials provider with email/password validation
- Password comparison using bcryptjs
- Google OAuth provider (conditional on environment variables)
- Custom session callback to include isSeller/isAdmin flags
- Fixed field mapping: avatarUrl→image for schema compatibility

**src/lib/auth-provider.tsx** (8 lines):
- Client-side SessionProvider wrapper component
- Enables `useSession()` hook throughout the app

**src/app/api/auth/[...nextauth]/route.ts** (3 lines):
- GET/POST API route handlers for NextAuth
- Handles signin, signout, callback, session endpoints

## Authentication Flow
1. User submits email/password
2. Credentials provider queries database
3. Password verified with bcryptjs.compare()
4. Session created in sessions table
5. Session token returned to client

## Test Plan
- [ ] Verify signin with email/password works
- [ ] Check session persists across page refreshes
- [ ] Confirm signout clears session
- [ ] Test Google OAuth (if credentials configured)
- [ ] Verify custom fields (isSeller, isAdmin) in session
- [ ] Check TypeScript types are correct

Generated with Claude Code