### PR TITLE
docs: add ralph-loop plugin to installation list

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,10 +48,14 @@ This project includes Claude Code CLI auto-installation in the devcontainer.
 **Setup:**
 - Claude Code CLI: Auto-installed during devcontainer build
 - First-time auth: Run `claude` to authenticate via browser (one-time)
-- Superpowers: Manual installation required (global, one-time):
+- Plugins: Manual installation required (global, one-time):
   ```
+  # Superpowers - TDD, planning, and review workflows
   /plugin marketplace add obra/superpowers-marketplace
   /plugin install superpowers@superpowers-marketplace
+
+  # Ralph Loop - Interactive development loop
+  /plugin install ralph-loop@claude-plugins-official
   ```
 
 **Integration:** Superpowers formalizes the TDD, planning, and review workflows already defined in `.claude/rules/` and `.claude/agents/`, providing additional structure through composable skills.


### PR DESCRIPTION
## Summary
- Added ralph-loop plugin from claude-plugins-official to the post-devcontainer setup documentation
- Updated plugin installation section to include both Superpowers and Ralph Loop with descriptive comments

## Test plan
- [x] Documentation is clear and accurate
- [x] Plugin installation command is correct
- [x] Formatting follows existing documentation style

Generated with [Claude Code](https://claude.com/claude-code)