### PR TITLE
fix: rename handover date label to exit timing

### DIFF
--- a/src/app/listing/[id]/confirm/page.tsx
+++ b/src/app/listing/[id]/confirm/page.tsx
@@ -346,7 +346,7 @@ export default function ConfirmListingPage() {
                   </div>
                   <div>
                     <label className="block text-sm font-medium text-foreground mb-2">
-                      引き継ぎ可能日（いつから）
+                      退去（引き渡し）希望時期
                       <span className="text-coral ml-1">*</span>
                     </label>
                     <input
@@ -356,6 +356,9 @@ export default function ConfirmListingPage() {
                       min={viewingAvailableFrom || new Date().toISOString().split("T")[0]}
                       className="w-full px-4 py-3 border border-border rounded-xl text-base focus:outline-none focus:ring-2 focus:ring-foreground"
                     />
+                    <p className="text-xs text-muted-foreground mt-1">
+                      ※実際の日程はクリーニング等により前後する場合があります
+                    </p>
                   </div>
                 </div>
               </div>

--- a/src/app/listing/[id]/pdf/page.tsx
+++ b/src/app/listing/[id]/pdf/page.tsx
@@ -195,9 +195,12 @@ export default function LandlordPDFPage() {
                   </td>
                 </tr>
                 <tr className="border-b border-gray-100">
-                  <td className="py-3 text-gray-500">引き継ぎ可能日</td>
+                  <td className="py-3 text-gray-500">退去（引き渡し）希望時期</td>
                   <td className="py-3 text-gray-900">
                     {listing.moveInAvailableFrom || "調整中"}
+                    <span className="block text-xs text-gray-400 mt-1">
+                      ※実際の日程はクリーニング等により前後する場合があります
+                    </span>
                   </td>
                 </tr>
               </tbody>

--- a/src/app/listing/[id]/preview/page.tsx
+++ b/src/app/listing/[id]/preview/page.tsx
@@ -295,10 +295,13 @@ export default function PreviewListingPage() {
                     <Calendar className="h-5 w-5 text-muted-foreground mt-0.5 flex-shrink-0" />
                     <div>
                       <p className="text-sm text-muted-foreground">
-                        引き継ぎ可能日
+                        退去（引き渡し）希望時期
                       </p>
                       <p className="text-base text-foreground">
                         {listing.moveInAvailableFrom}
+                      </p>
+                      <p className="text-xs text-muted-foreground mt-1">
+                        ※実際の日程はクリーニング等により前後する場合があります
                       </p>
                     </div>
                   </div>


### PR DESCRIPTION
## Summary
- Rename '引き継ぎ可能日' label to '退去（引き渡し）希望時期'
- Add disclaimer about cleaning schedule variance
- Follows BUSINESS.md terminology guidelines

## Changes
- `src/app/listing/[id]/preview/page.tsx`: Update label in preview display with disclaimer
- `src/app/listing/[id]/pdf/page.tsx`: Update label in PDF export with disclaimer
- `src/app/listing/[id]/confirm/page.tsx`: Update label in confirmation form with disclaimer

## Test plan
- [ ] Verify label appears correctly in listing preview
- [ ] Verify label appears in PDF export
- [ ] Verify label appears in confirmation form
- [ ] Verify disclaimer text is visible

Closes: tsumugi-k66

Generated with Claude Code