### PR TITLE
feat: add furniture listing strategy with viewing disclaimer

### DIFF
--- a/src/app/listing/new/page.tsx
+++ b/src/app/listing/new/page.tsx
@@ -683,6 +683,15 @@ export default function NewListingPage() {
                       );
                     })}
                   </div>
+
+                  {/* 内見時合意の注意書き */}
+                  <div className="mt-4 p-4 bg-blue-50 border border-blue-200 rounded-xl">
+                    <p className="text-sm text-blue-800">
+                      <span className="font-medium">ご注意：</span>
+                      ここで選択した家具は掲載時の参考情報です。
+                      最終的な譲渡内容や金額は内見時に双方で確認・合意します。
+                    </p>
+                  </div>
                 </div>
 
                 {/* AI見積もりカード */}

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -88,6 +88,14 @@ export interface SellerListing {
 // 引き継ぎ対象の大型家具
 export type LargeFurnitureType = "bed" | "sofa" | "desk" | "table" | "storage" | "dining" | "wardrobe" | "tv" | "fridge"
 
+// 家具アイテム（写真付き）
+export interface FurnitureItem {
+  type: LargeFurnitureType
+  photos: string[] // 家具の写真URL（最大3枚）
+  condition?: "excellent" | "good" | "fair" // 状態
+  notes?: string // 備考
+}
+
 // 引き継ぎ対象の大型家電
 export type LargeApplianceType = "washer" | "dryer" | "ac" | "microwave" | "dishwasher"
 
@@ -124,7 +132,8 @@ export interface UserListing {
   updatedAt: string
   publishedAt?: string
   // MVP後に追加検討
-  furniture?: LargeFurnitureType[] // 大型家具
+  furniture?: LargeFurnitureType[] // 大型家具（旧形式、互換性のため）
+  furnitureItems?: FurnitureItem[] // 家具アイテム（写真付き）
   story?: string
   // 公開前確認
   landlordConsent?: LandlordConsent // 大家承諾

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -89,6 +89,14 @@ export interface SellerListing {
 // 引き継ぎ対象の大型家具
 export type LargeFurnitureType = "bed" | "sofa" | "desk" | "table" | "storage" | "dining" | "wardrobe" | "tv" | "fridge"
 
+// 家具アイテム（写真付き）
+export interface FurnitureItem {
+  type: LargeFurnitureType
+  photos: string[] // 家具の写真URL（最大3枚）
+  condition?: "excellent" | "good" | "fair" // 状態
+  notes?: string // 備考
+}
+
 // 引き継ぎ対象の大型家電
 export type LargeApplianceType = "washer" | "dryer" | "ac" | "microwave" | "dishwasher"
 
@@ -124,7 +132,8 @@ export interface UserListing {
   createdAt: string
   updatedAt: string
   publishedAt?: string
-  furniture?: LargeFurnitureType[] // 大型家具
+  furniture?: LargeFurnitureType[] // 大型家具（旧形式、互換性のため）
+  furnitureItems?: FurnitureItem[] // 家具アイテム（写真付き）
   story?: string
   landlordConsent?: LandlordConsent // 大家承諾
   liabilityTerms?: LiabilityTerms // 責任区分


### PR DESCRIPTION
## Summary
- Adds FurnitureItem interface with photos, condition, and notes support
- Updates UserListing type to support detailed furniture items
- Adds disclaimer in Step 6 (furniture selection) explaining that final agreement is at viewing

## Context
Per BUSINESS.md (lines 128-143), we use a "hybrid" approach:
- List furniture upfront with details at listing time (helps matching)
- Add disclaimer that final agreement happens at viewing
- This approach increases matching rate while preventing disputes

## Changes
- `src/lib/types.ts`: New FurnitureItem interface
- `src/lib/data.ts`: Same FurnitureItem interface for consistency
- `src/app/listing/new/page.tsx`: Disclaimer added to Step 6

## Test plan
- [ ] Verify furniture selection still works in Step 6
- [ ] Verify disclaimer is visible below furniture grid
- [ ] Verify types compile without errors

Closes tsumugi-lzv