### PR TITLE
feat: add AI-powered estimate service using Claude API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,5 +28,11 @@ AWS_S3_BUCKET_NAME="tsumugi-images"
 RESEND_API_KEY=""
 EMAIL_FROM="noreply@tsumugi.example.com"
 
+# AI Estimate Service (Optional)
+# Anthropic API: https://console.anthropic.com/
+ANTHROPIC_API_KEY=""
+# Set to "true" to enable AI-powered estimates (requires ANTHROPIC_API_KEY)
+NEXT_PUBLIC_USE_AI_ESTIMATE="false"
+
 # Environment
 NODE_ENV="development"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "my-v0-project",
       "version": "0.1.0",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.72.1",
         "@auth/core": "^0.41.0",
         "@auth/drizzle-adapter": "^1.11.1",
         "@hookform/resolvers": "^3.10.0",
@@ -92,6 +93,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.72.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.72.1.tgz",
+      "integrity": "sha512-MiUnue7qN7DvLIoYHgkedN2z05mRf2CutBzjXXY2krzOhG2r/rIfISS2uVkNLikgToB5hYIzw+xp2jdOtRkqYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@auth/core": {
@@ -5361,6 +5382,19 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -6856,6 +6890,12 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "worktree:prune": "git worktree prune"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.72.1",
     "@auth/core": "^0.41.0",
     "@auth/drizzle-adapter": "^1.11.1",
     "@hookform/resolvers": "^3.10.0",

--- a/src/app/api/estimate/route.ts
+++ b/src/app/api/estimate/route.ts
@@ -1,0 +1,128 @@
+import Anthropic from "@anthropic-ai/sdk"
+import { NextRequest, NextResponse } from "next/server"
+
+import type { EstimateInput, EstimateResult } from "@/lib/estimate-service"
+
+const FURNITURE_LABELS: Record<string, string> = {
+  bed: "ベッド",
+  sofa: "ソファ",
+  desk: "デスク",
+  table: "テーブル",
+  storage: "収納",
+  wardrobe: "ワードローブ",
+  tv: "テレビ台",
+  fridge: "冷蔵庫",
+}
+
+function buildPrompt(input: EstimateInput): string {
+  const furnitureList = input.furniture
+    .map((f) => FURNITURE_LABELS[f] || f)
+    .join("、")
+
+  return `あなたは日本の不動産市場における家具・インテリアの価値評価の専門家です。
+以下の条件で、家具の処分費用と引き継ぎ価値を見積もってください。
+
+## 条件
+- エリア: ${input.area}
+- 家具リスト: ${furnitureList}
+${input.rent ? `- 家賃: ${input.rent.toLocaleString()}円/月` : ""}
+${input.layout ? `- 間取り: ${input.layout}` : ""}
+
+## 出力形式
+以下のJSON形式で回答してください。金額は全て日本円の整数値で、1000円単位に丸めてください。
+
+{
+  "disposalCostMin": 処分費用の最小値,
+  "disposalCostMax": 処分費用の最大値,
+  "handoverFeeMin": 引き継ぎ金額の最小値,
+  "handoverFeeMax": 引き継ぎ金額の最大値,
+  "breakdown": [
+    {
+      "item": "家具名",
+      "disposalCost": 処分費用,
+      "handoverValue": 引き継ぎ価値
+    }
+  ]
+}
+
+## 考慮事項
+- 都心部（渋谷区、港区、目黒区、世田谷区など）は家具の価値が少し高くなる傾向
+- 処分費用は自治体の粗大ごみ料金や業者の回収費用を参考に
+- 引き継ぎ価値は中古家具市場の相場や利便性を考慮
+- 家具の状態は「良好」を仮定
+
+JSON形式のみで回答してください。説明文は不要です。`
+}
+
+function parseAIResponse(content: string): EstimateResult {
+  const jsonMatch = content.match(/\{[\s\S]*\}/)
+  if (!jsonMatch) {
+    throw new Error("AI response does not contain valid JSON")
+  }
+
+  const parsed = JSON.parse(jsonMatch[0])
+
+  const savingsMin = parsed.handoverFeeMin + parsed.disposalCostMin
+  const savingsMax = parsed.handoverFeeMax + parsed.disposalCostMax
+
+  return {
+    disposalCostMin: parsed.disposalCostMin,
+    disposalCostMax: parsed.disposalCostMax,
+    handoverFeeMin: parsed.handoverFeeMin,
+    handoverFeeMax: parsed.handoverFeeMax,
+    savingsMin,
+    savingsMax,
+    breakdown: parsed.breakdown,
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const apiKey = process.env.ANTHROPIC_API_KEY
+    if (!apiKey) {
+      return NextResponse.json(
+        { error: "ANTHROPIC_API_KEY not configured" },
+        { status: 500 }
+      )
+    }
+
+    const input: EstimateInput = await request.json()
+
+    if (!input.furniture || input.furniture.length === 0) {
+      return NextResponse.json({
+        disposalCostMin: 0,
+        disposalCostMax: 0,
+        handoverFeeMin: 0,
+        handoverFeeMax: 0,
+        savingsMin: 0,
+        savingsMax: 0,
+        breakdown: [],
+      })
+    }
+
+    const client = new Anthropic({ apiKey })
+    const prompt = buildPrompt(input)
+
+    const message = await client.messages.create({
+      model: "claude-sonnet-4-20250514",
+      max_tokens: 1024,
+      messages: [{ role: "user", content: prompt }],
+    })
+
+    const textContent = message.content.find((block) => block.type === "text")
+    if (!textContent || textContent.type !== "text") {
+      throw new Error("No text content in AI response")
+    }
+
+    const result = parseAIResponse(textContent.text)
+    return NextResponse.json(result)
+  } catch (error) {
+    if (error instanceof Error) {
+      return NextResponse.json({ error: error.message }, { status: 500 })
+    }
+    return NextResponse.json(
+      { error: "Failed to generate estimate" },
+      { status: 500 }
+    )
+  }
+}

--- a/src/lib/estimate-service.ts
+++ b/src/lib/estimate-service.ts
@@ -96,18 +96,24 @@ function calculateMockEstimate(input: EstimateInput): EstimateResult {
   }
 }
 
-// TODO: Claude APIを使った実装に切り替える場合はここを変更
-// async function calculateAIEstimate(input: EstimateInput): Promise<EstimateResult> {
-//   const response = await fetch("/api/estimate", {
-//     method: "POST",
-//     headers: { "Content-Type": "application/json" },
-//     body: JSON.stringify(input),
-//   })
-//   return response.json()
-// }
+// Claude APIを使った見積もり計算
+async function calculateAIEstimate(input: EstimateInput): Promise<EstimateResult> {
+  const response = await fetch("/api/estimate", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  })
 
-// 現在の実装を切り替えるフラグ
-const USE_AI = false
+  if (!response.ok) {
+    throw new Error(`API request failed: ${response.status}`)
+  }
+
+  return response.json()
+}
+
+// AI実装を使用するかどうかのフラグ
+// 環境変数 NEXT_PUBLIC_USE_AI_ESTIMATE=true で有効化
+const USE_AI = process.env.NEXT_PUBLIC_USE_AI_ESTIMATE === "true"
 
 export async function getEstimate(input: EstimateInput): Promise<EstimateResult> {
   // 家具が選択されていない場合はデフォルト値を返す
@@ -124,8 +130,12 @@ export async function getEstimate(input: EstimateInput): Promise<EstimateResult>
   }
 
   if (USE_AI) {
-    // TODO: AI実装に切り替え
-    // return calculateAIEstimate(input)
+    try {
+      return await calculateAIEstimate(input)
+    } catch (error) {
+      // AI APIが失敗した場合はモック実装にフォールバック
+      console.error("AI estimate failed, falling back to mock:", error)
+    }
   }
 
   // モック実装を使用


### PR DESCRIPTION
## Summary
- Integrate Anthropic Claude API for intelligent furniture estimate calculations
- Add server-side API route `/api/estimate` to handle Claude API calls securely
- Update `estimate-service.ts` with AI-powered estimates and automatic fallback to mock implementation
- Feature is opt-in via `NEXT_PUBLIC_USE_AI_ESTIMATE=true` environment variable

## Changes
- `package.json` - Added `@anthropic-ai/sdk` dependency
- `src/app/api/estimate/route.ts` - New API route for Claude API integration
- `src/lib/estimate-service.ts` - Updated to support AI estimates with fallback
- `.env.example` - Added `ANTHROPIC_API_KEY` and `NEXT_PUBLIC_USE_AI_ESTIMATE` variables

## Test plan
- [ ] Verify mock estimates work when `NEXT_PUBLIC_USE_AI_ESTIMATE` is not set
- [ ] Test AI estimates with valid `ANTHROPIC_API_KEY` and `NEXT_PUBLIC_USE_AI_ESTIMATE=true`
- [ ] Confirm fallback to mock when API key is missing or invalid
- [ ] Verify estimate calculations return proper JSON structure

🤖 Generated with [Claude Code](https://claude.ai/code)