### PR TITLE
chore: enable TypeScript LSP plugin by default

### DIFF
--- a/.devcontainer/install-plugins.sh
+++ b/.devcontainer/install-plugins.sh
@@ -16,11 +16,11 @@ PLUGINS=(
   "serena"
   "context7"
   "linear"
+  "typescript-lsp"
 )
 
 # Optional plugins (disabled by default)
 OPTIONAL_PLUGINS=(
-  "typescript-lsp"
 )
 
 echo "Installing Claude Code plugins..."


### PR DESCRIPTION
## Summary
- Enable TypeScript LSP plugin by default in devcontainer
- Move from optional to enabled plugins for better TypeScript integration

## Changes
- Moved `typescript-lsp` from `OPTIONAL_PLUGINS` to `PLUGINS` array in `.devcontainer/install-plugins.sh`

## Test Plan
- [x] Build completes successfully
- [x] Linter passes (warnings only, no errors)
- [ ] Verify TypeScript LSP works in devcontainer after rebuild

Generated with Claude Code