### PR TITLE
fix(ci): add required environment variables for E2E build step

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -38,6 +38,9 @@ jobs:
         run: npm run build
         env:
           NODE_ENV: production
+          DATABASE_URL: postgresql://user:password@localhost:5432/test_db
+          NEXTAUTH_URL: http://localhost:3000
+          NEXTAUTH_SECRET: test-secret-for-ci-builds-only
 
       - name: Run E2E tests
         run: npm run test:e2e


### PR DESCRIPTION
## Summary
- Fixes Next.js build failure in E2E workflow
- Adds required environment variables for NextAuth during build time

## Problem
The E2E test workflow was failing with:
```
Error: DATABASE_URL environment variable is not set
```

This occurred because NextAuth configuration (`/api/auth/[...nextauth]`) is evaluated during the Next.js build step, and it requires certain environment variables to be present.

## Solution
Added test environment variables to the build step:
- `DATABASE_URL` - PostgreSQL connection string for build-time checks
- `NEXTAUTH_URL` - Required by NextAuth configuration
- `NEXTAUTH_SECRET` - Required by NextAuth configuration

These values are only used during build and do not connect to real services.

## Test Plan
- [ ] E2E workflow runs successfully
- [ ] Build step completes without errors
- [ ] Tests execute as expected

Generated with [Claude Code](https://claude.com/claude-code)