### PR TITLE
docs: add E2E test GitHub Pages link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ A Node.js/TypeScript project with devcontainer support.
 - `npm run start` - Run the compiled JavaScript
 - `npm run dev` - Run in development mode with hot reload
 - `npm test` - Run tests
+- `npm run test:e2e` - Run E2E tests with Playwright
 
 ## Project Structure
 
@@ -36,5 +37,12 @@ A Node.js/TypeScript project with devcontainer support.
 ├── tsconfig.json
 └── README.md
 ```
+
+## E2E Test Reports
+
+View the latest E2E test results and screenshots:
+- GitHub Pages: https://kokiebisu.github.io/tsumugi/e2e-reports/
+
+E2E tests run automatically on every PR and push to main. Test reports include screenshots, videos, and traces for debugging failures.
 
 # tsumugi


### PR DESCRIPTION
## Summary
- Added E2E test reports section to README.md with GitHub Pages link
- Added `npm run test:e2e` to Available Scripts section
- Provides direct access to test results, screenshots, videos, and traces

## Test plan
- [x] Verified link matches the E2E test GitHub Pages URL from CLAUDE.md
- [x] Documentation-only change, no code changes

Generated with [Claude Code](https://claude.com/claude-code)