### PR TITLE
docs: update README with tsumugi project information

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,48 +1,128 @@
-# DevContainer Project
+# tsumugi（紡ぎ）
 
-A Node.js/TypeScript project with devcontainer support.
+> 住人の暮らしを引き継ぐプラットフォーム
+> A platform for inheriting someone's living space and lifestyle
 
-## Features
+tsumugi connects people leaving their homes ("前の住人" - previous residents) with those looking to inherit not just a space, but a complete lifestyle. Furniture, neighborhood knowledge, daily routines - everything that makes a house a home.
 
-- Node.js 20
-- TypeScript
-- Git
-- Docker-in-Docker support
+## Tech Stack
 
-## Getting Started
+- **Framework:** Next.js 16 (App Router)
+- **Language:** TypeScript
+- **Styling:** Tailwind CSS
+- **UI Components:** shadcn/ui (Radix UI)
+- **Node Version:** 20
+- **Package Manager:** npm
+
+## Quick Start
+
+### Prerequisites
+
+This project uses VS Code devcontainers for a consistent development environment.
+
+### Setup
 
 1. Open this folder in VS Code
 2. When prompted, click "Reopen in Container" (or use Command Palette: "Dev Containers: Reopen in Container")
-3. VS Code will build the container and set up the environment
-4. Once ready, run `npm run dev` to start the development server
+3. Wait for the container to build (Claude Code CLI will auto-install)
+4. Run `npm run dev` to start the development server at http://localhost:3000
 
-## Available Scripts
+## Development Commands
 
-- `npm run build` - Compile TypeScript to JavaScript
-- `npm run start` - Run the compiled JavaScript
-- `npm run dev` - Run in development mode with hot reload
-- `npm test` - Run tests
-- `npm run test:e2e` - Run E2E tests with Playwright
+```bash
+npm run dev              # Start development server (localhost:3000)
+npm run build            # Production build
+npm run start            # Start production server
+npm run lint             # Run ESLint
+npm test                 # Run tests
+npm run test:e2e         # Run E2E tests with Playwright
+```
+
+## Development Tools
+
+### Beads Task Tracker
+
+AI-friendly task tracking with dependency management:
+
+```bash
+bd ready              # Show tasks with no blockers
+bd create "Task"      # Create new task
+bd status --json      # Get JSON output for agents
+bd done <id>          # Mark task complete
+bd show <id>          # Show task details and dependencies
+```
+
+Tasks are stored in `.beads/` and shared across git worktrees. [Learn more](https://github.com/steveyegge/beads)
+
+### Claude Code CLI
+
+Auto-installed in the devcontainer with persistent authentication:
+
+- Config directory (`~/.claude`) mounted from host machine
+- One-time browser authentication persists permanently
+- Pre-configured with plugins: superpowers, context7, typescript-lsp, ralph-loop, code-review, and more
+- See `.claude/settings.json` for full plugin list
+
+### E2E Test Reports
+
+View latest test results with screenshots, videos, and traces:
+- **GitHub Pages:** https://kokiebisu.github.io/tsumugi/e2e-reports/
+
+Tests run automatically on every PR and push to main.
 
 ## Project Structure
 
 ```
-.
-├── .devcontainer/
-│   ├── devcontainer.json
-│   └── Dockerfile
-├── src/
-│   └── index.ts
-├── package.json
-├── tsconfig.json
-└── README.md
+src/
+├── app/                  # Next.js App Router pages
+│   ├── page.tsx          # Home page
+│   ├── layout.tsx        # Root layout
+│   ├── properties/       # Property listings & details
+│   ├── listing/          # Listing management for previous residents
+│   └── account/          # User account pages
+├── components/           # React components
+│   ├── ui/               # shadcn/ui components
+│   ├── auth/             # Authentication components
+│   └── listing/          # Listing creation flow
+├── contexts/             # React contexts
+│   └── auth-context.tsx  # Authentication state management
+└── lib/                  # Utilities & data layer
+    ├── data.ts           # Property data & type definitions
+    ├── utils.ts          # Utility functions
+    └── site-config.ts    # Site configuration
 ```
 
-## E2E Test Reports
+## Environment Variables
 
-View the latest E2E test results and screenshots:
-- GitHub Pages: https://kokiebisu.github.io/tsumugi/e2e-reports/
+Create a `.env.local` file for sensitive data:
 
-E2E tests run automatically on every PR and push to main. Test reports include screenshots, videos, and traces for debugging failures.
+```bash
+LINEAR_API_KEY=your_key_here    # Linear API for issue tracking sync
+```
 
-# tsumugi
+Load before running commands that need API keys:
+```bash
+source .env.local
+```
+
+## Automated Workflows
+
+### Daily Requirements Audit
+
+Runs daily at 9:00 AM JST via GitHub Actions:
+1. Compares REQUIREMENTS.md / BUSINESS.md with actual code
+2. Detects implementation gaps using Claude API
+3. Creates Beads tasks for any gaps found
+4. Auto-creates and merges PR if gaps exist
+
+**Manual trigger:**
+```bash
+gh workflow run "Requirements Audit"
+```
+
+## Documentation
+
+- `CLAUDE.md` - Development guide (commands, tools, workflows)
+- `.claude/PROJECT.md` - Project specification (concept, design principles)
+- `.claude/BUSINESS.md` - Business logic (pricing, inheritance flow)
+- `.devcontainer/WORKTREE.md` - Git worktree documentation


### PR DESCRIPTION
## Summary

Updated README.md to accurately reflect the tsumugi project instead of the generic devcontainer template.

## Changes

- **Project description**: Added tsumugi's purpose as a platform for inheriting living spaces and lifestyles
- **Tech stack**: Updated to show actual Next.js 16, TypeScript, Tailwind CSS, shadcn/ui stack
- **Development tools**: 
  - Added Beads task tracker documentation
  - Added Claude Code CLI setup and plugin information
  - Included E2E test reports GitHub Pages link
- **Project structure**: Updated to reflect actual `src/app/` directory structure
- **Environment variables**: Documented `.env.local` setup
- **Automated workflows**: Added Daily Requirements Audit documentation
- **Documentation links**: Added references to CLAUDE.md, PROJECT.md, BUSINESS.md, WORKTREE.md

## Test Plan

- [x] README displays correctly on GitHub
- [x] All links are valid
- [x] Code blocks render properly
- [x] Information matches actual project setup

Generated with [Claude Code](https://claude.com/claude-code)