### PR TITLE
docs: add Docker swap configuration to prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ tsumugi connects people leaving their homes ("前の住人" - previous residents
 
 This project uses VS Code devcontainers for a consistent development environment.
 
+**Required Docker Configuration:**
+- **Swap:** 4GB minimum (prevents OOM kills during Claude sessions)
+  - Docker Desktop: Settings → Resources → Swap → Set to 4GB
+  - Background services (TypeScript, ESLint) and Claude sessions can consume significant memory
+  - Default 1GB swap causes "killed" errors when running multiple sessions
+
 ### Setup
 
 1. Open this folder in VS Code


### PR DESCRIPTION
## Summary

Add 4GB Docker swap requirement to README prerequisites section to prevent OOM (Out Of Memory) kills during development.

## Problem

Users encounter "zsh: killed claude" errors when:
- Running multiple Claude CLI sessions concurrently
- Background services (TypeScript/ESLint language servers) consume swap space
- Default Docker swap (1GB) becomes exhausted
- System OOM killer terminates processes to free memory

## Solution

Document the requirement for 4GB Docker swap in prerequisites with:
- Clear minimum requirement (4GB)
- Location to configure (Docker Desktop → Settings → Resources → Swap)
- Explanation of why it's needed
- Context about what consumes memory

## Changes

- Add "Required Docker Configuration" section to Prerequisites
- Specify 4GB swap minimum with rationale
- Provide configuration instructions

## Test Plan

- [x] Documentation is clear and actionable
- [x] No other files modified
- [x] Follows docs style

🤖 Generated with [Claude Code](https://claude.com/claude-code)