### PR TITLE
ci: make E2E tests opt-in for PRs

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,8 +1,9 @@
 name: E2E Tests
 
 on:
+  workflow_dispatch:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, labeled]
   push:
     branches:
       - main
@@ -35,12 +36,16 @@ jobs:
           script: |
             const labels = context.payload.pull_request.labels.map(l => l.name);
 
-            if (labels.includes('e2e:skip')) {
+            // Check for any E2E-related labels
+            const hasE2ELabel = labels.some(l => l.startsWith('e2e:'));
+
+            if (!hasE2ELabel) {
+              // No E2E label = skip tests
               core.setOutput('skip', 'true');
               return;
             }
 
-            if (labels.includes('e2e:full-suite')) {
+            if (labels.includes('e2e:full-suite') || labels.includes('e2e:run')) {
               core.setOutput('full-suite', 'true');
               return;
             }
@@ -50,6 +55,7 @@ jobs:
               return;
             }
 
+            // Has E2E label but not a specific one - run full suite by default
             core.setOutput('skip', 'false');
 
       - name: Setup Node.js
@@ -289,7 +295,8 @@ jobs:
                     comment += '\n';
                   }
 
-                  comment += '💡 **Note:** Full suite will run when merged to main\n\n';
+                  comment += '💡 **Note:** Full E2E suite will run when merged to main\n\n';
+                  comment += '**To run E2E tests on PRs:** Add labels `e2e:run`, `e2e:full-suite`, or `e2e:critical-only`\n\n';
                 }
 
                 comment += '### 📊 Test Results\n\n';


### PR DESCRIPTION
## Summary

Changes E2E test workflow from automatic to opt-in for pull requests.

### Changes Made

- **Added `workflow_dispatch` trigger** - allows manual E2E runs from GitHub Actions UI
- **Changed PR trigger** - Added `labeled` event to respond when labels are added
- **Inverted label logic** - Default is now to skip E2E tests on PRs
- **Opt-in labels**:
  - `e2e:run` - Run full E2E suite
  - `e2e:full-suite` - Run full E2E suite
  - `e2e:critical-only` - Run only @critical tagged tests
- **Kept main branch behavior** - Full suite still runs automatically on main pushes
- **Updated PR comments** - Added instructions on how to trigger E2E tests

### Behavior

**Before:** E2E tests ran automatically on every PR (could skip with `e2e:skip` label)

**After:** 
- PRs: Skip E2E by default (add `e2e:*` label to run)
- Main branch: Still runs full suite automatically
- Manual: Can trigger via GitHub Actions UI anytime

### Benefits

- Faster CI for most PRs
- Developer control over when to run expensive E2E tests
- Still maintains coverage on main branch
- Can manually trigger for any branch when needed

### Test Plan

- [ ] Create a test PR without labels - should skip E2E
- [ ] Add `e2e:run` label - should trigger E2E tests
- [ ] Verify main branch push still runs full suite
- [ ] Test manual workflow_dispatch trigger

Generated with Claude Code