### PR TITLE
docs: add branch cleanup instructions to /pr skill

### DIFF
--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -118,6 +118,42 @@ For each approved group:
 
 6. **Report PR URL and status** after creation
 
+## Step 6: Wait for CI and Merge
+
+After PR is created:
+
+1. **Monitor CI checks**:
+   ```bash
+   gh pr checks <pr-number>
+   ```
+
+2. **Wait for all checks to pass** - Do NOT proceed if any check fails
+
+3. **Merge PR and delete remote branch**:
+   ```bash
+   gh pr merge <pr-number> --squash --delete-branch
+   ```
+
+   This deletes the **remote branch** on GitHub.
+
+4. **Clean up local workspace**:
+   ```bash
+   # Switch to main (if not already there)
+   git checkout main
+
+   # Pull latest changes
+   git pull origin main
+
+   # Delete local feature branch
+   git branch -d <feature-branch-name>
+   ```
+
+   This deletes the **local branch**.
+
+**Result**: Both remote and local branches are deleted.
+
+**Note**: If `git branch -d` fails with "branch not found", it means the branch was already deleted (no action needed).
+
 ## Rules
 
 - **ALWAYS create PRs automatically** - Never just push and tell user to create PR manually


### PR DESCRIPTION
## Summary

- Added Step 6 to the `/pr` skill documenting post-merge cleanup workflow
- Clarifies how to delete both remote and local branches after PR merge
- Addresses confusion about `gh pr merge --delete-branch` only deleting remote

## Changes

- **Step 6: Wait for CI and Merge**: New section with complete workflow
  - Monitor CI checks with `gh pr checks`
  - Merge with `--delete-branch` flag (deletes remote branch)
  - Clean up local workspace (checkout main, pull, delete local branch)
- **Clarifications**: Explicitly states which commands delete remote vs local
- **Edge case handling**: Note about "branch not found" being expected behavior

## Test Plan

- [x] Lint passes
- [x] Markdown syntax is valid
- [ ] User verification: Follow new cleanup steps after next PR merge
- [ ] User verification: Confirm both branches are deleted successfully

## Impact

**Documentation**: Prevents confusion and manual branch cleanup errors by providing clear, step-by-step instructions for complete cleanup of both remote and local branches.

Generated with Claude Code