### PR TITLE
fix: correct test runner usage to use Vitest instead of Bun

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,12 @@ bun start                # プロダクションサーバー起動
 bun lint                 # ESLintでコードチェック
 ./dev                    # Open devcontainer with Claude Code (auto-starts)
 
+# Testing (IMPORTANT: Use "bun run test", NOT "bun test")
+bun run test             # Run unit tests with Vitest (watch mode)
+bun run test:run         # Run unit tests once and exit
+bun run test:ui          # Run tests with Vitest UI
+bun run test:e2e         # Run E2E tests with Playwright
+
 # Git Worktrees (with devcontainer support)
 npm run worktree:create  # 新しいworktreeを作成 (still uses npm script runner)
 npm run worktree:list    # worktree一覧を表示

--- a/README.md
+++ b/README.md
@@ -60,7 +60,11 @@ bun dev                  # Start development server (localhost:3000)
 bun run build            # Production build
 bun start                # Start production server
 bun lint                 # Run ESLint
-bun test                 # Run tests
+
+# Testing (IMPORTANT: Use "bun run test", NOT "bun test")
+# (bun test uses Bun's built-in test runner instead of Vitest)
+bun run test             # Run unit tests with Vitest (watch mode)
+bun run test:run         # Run unit tests once and exit
 bun run test:e2e         # Run E2E tests with Playwright
 
 # Git Worktrees (for isolated development)

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "format:check": "prettier --check .",
     "prepare": "git config core.hooksPath .githooks || true",
     "test": "vitest",
+    "test:run": "vitest run",
     "test:ui": "vitest --ui",
     "shell": "./dev",
     "test:e2e": "playwright test",


### PR DESCRIPTION
## Summary

- Fixed test failures caused by running tests with Bun's built-in test runner instead of Vitest
- `bun test` uses Bun's test runner which doesn't support Vitest features like `vi.mocked()`
- `bun run test` correctly uses Vitest as configured in package.json

## Changes

- Added `test:run` script to package.json for one-time test runs
- Updated CLAUDE.md with testing commands and warning about correct usage
- Updated README.md with testing commands and warning about correct usage
- Added comments explaining why `bun run test` must be used

## Root Cause

When running `bun test` directly, Bun intercepts the command and uses its built-in test runner instead of delegating to the npm script. This causes:
- `vi.mocked()` errors (Bun doesn't support this Vitest function)
- Playwright tests being loaded (Bun doesn't respect vitest.config.ts exclusions)

## Test Plan

- [x] Run `bun run test` - All 112 tests pass
- [x] Run `bun run test:run` - All 112 tests pass
- [x] Type check passes (`bunx tsc --noEmit`)
- [x] Verified documentation is clear and accurate

Generated with Claude Code