### PR TITLE
fix: update E2E test selectors for stability

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -160,6 +160,7 @@ export default function DashboardPage() {
                 return (
                   <div
                     key={inquiry.id}
+                    data-testid="inquiry-card"
                     className="rounded-xl border border-border bg-background p-6 shadow-sm"
                   >
                     {/* 物件情報 */}

--- a/tests/e2e/dashboard/dashboard.spec.ts
+++ b/tests/e2e/dashboard/dashboard.spec.ts
@@ -81,7 +81,7 @@ test.describe('Dashboard - With Inquiries', () => {
     await page.goto('/dashboard');
 
     // Should show at least one inquiry
-    const inquiryCards = page.locator('[class*="inquiry"], [class*="card"]');
+    const inquiryCards = page.locator('[data-testid="inquiry-card"]');
     await expect(inquiryCards.first()).toBeVisible();
   });
 

--- a/tests/e2e/inquiry/inquiry-flow.spec.ts
+++ b/tests/e2e/inquiry/inquiry-flow.spec.ts
@@ -298,7 +298,9 @@ test.describe('Inquiry Flow - Form Validation @inquiry @extended', () => {
 
     // Should show helper text explaining email usage
     await expect(
-      page.locator('text=ご連絡はこちらのメールアドレスに送らせていただきます')
+      page
+        .getByRole('main')
+        .locator('text=ご連絡はこちらのメールアドレスに送らせていただきます')
     ).toBeVisible();
   });
 


### PR DESCRIPTION
## Summary

Fixed two failing E2E tests in GitHub Actions by updating test selectors to be more stable and specific.

## Changes

### 1. Dashboard inquiry cards test (dashboard.spec.ts:80)

**Problem:** Test used fragile CSS selector `[class*="inquiry"], [class*="card"]` that didn't match actual rendered HTML.

**Solution:** 
- Added `data-testid="inquiry-card"` attribute to inquiry cards
- Updated test to use stable selector: `page.locator('[data-testid="inquiry-card"]')`

### 2. Email helper text test (inquiry-flow.spec.ts:296)

**Problem:** Playwright strict mode violation - found 2 elements with same text, likely due to React hydration creating temporary duplicates.

**Solution:**
- Scoped selector to main content area: `page.getByRole('main').locator('text=...')`
- Ensures we only match the text in the main form, not potential duplicates

## Files Modified

- `src/app/dashboard/page.tsx` - Added data-testid attribute
- `tests/e2e/dashboard/dashboard.spec.ts` - Updated selector
- `tests/e2e/inquiry/inquiry-flow.spec.ts` - Scoped selector to main role

## Test Plan

- [x] E2E tests should pass in GitHub Actions
- [x] No other tests broken
- [x] Selectors follow best practices (data-testid, scoped selectors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)