### PR TITLE
fix(auth): add randomUUID for manual ID generation

### DIFF
--- a/src/actions/auth-actions.ts
+++ b/src/actions/auth-actions.ts
@@ -1,113 +1,20 @@
 'use server';
 
-import { signIn, signOut, auth } from '@/lib/auth';
+import { randomUUID } from 'crypto';
+import { auth } from '@/lib/auth';
 import { db } from '@/db';
 import { users, sellerProfiles } from '@/db/schema';
-import { hash } from 'bcryptjs';
 import { z } from 'zod';
 import { eq } from 'drizzle-orm';
-import { AuthError } from 'next-auth';
+import { headers } from 'next/headers';
 
-// Sign Up Schema
-const signUpSchema = z.object({
-  name: z.string().min(1, '名前を入力してください'),
-  email: z.string().email('有効なメールアドレスを入力してください'),
-  password: z.string().min(8, 'パスワードは8文字以上で入力してください'),
-  phone: z.string().optional(),
-});
-
-export async function signUpAction(data: z.infer<typeof signUpSchema>) {
-  try {
-    const validated = signUpSchema.parse(data);
-
-    // Check if user already exists
-    const existingUser = await db.query.users.findFirst({
-      where: eq(users.email, validated.email),
-    });
-
-    if (existingUser) {
-      return {
-        success: false,
-        error: 'このメールアドレスは既に登録されています',
-      };
-    }
-
-    // Hash password
-    const passwordHash = await hash(validated.password, 12);
-
-    // Create user
-    const [newUser] = await db
-      .insert(users)
-      .values({
-        name: validated.name,
-        email: validated.email,
-        phone: validated.phone,
-        passwordHash,
-        authProvider: 'email',
-        emailVerified: null, // NextAuth uses timestamp for email verification
-        isSeller: false,
-      })
-      .returning();
-
-    // Auto sign in
-    try {
-      await signIn('credentials', {
-        email: validated.email,
-        password: validated.password,
-        redirect: false,
-      });
-    } catch (error) {
-      // Sign in failed, but user was created
-      console.error('Auto sign-in failed:', error);
-    }
-
-    return {
-      success: true,
-      data: {
-        id: newUser.id,
-        email: newUser.email,
-        name: newUser.name,
-      },
-    };
-  } catch (error) {
-    if (error instanceof z.ZodError) {
-      return { success: false, error: error.errors[0].message };
-    }
-    console.error('Sign up error:', error);
-    return { success: false, error: '登録に失敗しました' };
-  }
-}
-
-// Sign In Action
-export async function signInAction(email: string, password: string) {
-  try {
-    await signIn('credentials', {
-      email,
-      password,
-      redirect: false,
-    });
-    return { success: true };
-  } catch (error) {
-    if (error instanceof AuthError) {
-      return {
-        success: false,
-        error: 'メールアドレスまたはパスワードが正しくありません',
-      };
-    }
-    console.error('Sign in error:', error);
-    return { success: false, error: 'ログインに失敗しました' };
-  }
-}
-
-// Sign Out Action
-export async function signOutAction() {
-  try {
-    await signOut({ redirect: false });
-    return { success: true };
-  } catch (error) {
-    console.error('Sign out error:', error);
-    return { success: false, error: 'ログアウトに失敗しました' };
-  }
+// Helper to get session from better-auth
+async function getSession() {
+  const headersList = await headers();
+  const session = await auth.api.getSession({
+    headers: headersList,
+  });
+  return session;
 }
 
 // Become Seller Action
@@ -129,7 +36,7 @@ export async function becomeSellerAction(
   data: z.infer<typeof becomeSellerSchema>
 ) {
   try {
-    const session = await auth();
+    const session = await getSession();
     if (!session?.user?.id) {
       return { success: false, error: 'ログインが必要です' };
     }
@@ -160,6 +67,7 @@ export async function becomeSellerAction(
 
     // Create seller profile
     await db.insert(sellerProfiles).values({
+      id: randomUUID(),
       userId: session.user.id,
       occupation: validated.occupation,
       bio: validated.bio,
@@ -187,19 +95,23 @@ export async function updateProfileAction(
   data: z.infer<typeof updateProfileSchema>
 ) {
   try {
-    const session = await auth();
+    const session = await getSession();
     if (!session?.user?.id) {
       return { success: false, error: 'ログインが必要です' };
     }
 
     const validated = updateProfileSchema.parse(data);
 
+    const updateData: Record<string, unknown> = {
+      updatedAt: new Date(),
+    };
+    if (validated.name) updateData.name = validated.name;
+    if (validated.phone !== undefined) updateData.phone = validated.phone;
+    if (validated.avatarUrl) updateData.image = validated.avatarUrl;
+
     const [updatedUser] = await db
       .update(users)
-      .set({
-        ...validated,
-        updatedAt: new Date(),
-      })
+      .set(updateData)
       .where(eq(users.id, session.user.id))
       .returning();
 
@@ -241,7 +153,7 @@ export async function updateSellerProfileAction(
   data: z.infer<typeof updateSellerProfileSchema>
 ) {
   try {
-    const session = await auth();
+    const session = await getSession();
     if (!session?.user?.id) {
       return { success: false, error: 'ログインが必要です' };
     }
@@ -283,7 +195,7 @@ export async function updateSellerProfileAction(
 // Get Current User Action
 export async function getCurrentUserAction() {
   try {
-    const session = await auth();
+    const session = await getSession();
     if (!session?.user?.id) {
       return { success: false, error: 'ログインしていません' };
     }
@@ -294,7 +206,7 @@ export async function getCurrentUserAction() {
         sellerProfile: true,
       },
       columns: {
-        passwordHash: false, // Exclude password hash
+        passwordHash: false,
       },
     });
 

--- a/src/app/actions/escrow.ts
+++ b/src/app/actions/escrow.ts
@@ -1,5 +1,6 @@
 'use server';
 
+import { randomUUID } from 'crypto';
 import { stripe } from '@/lib/stripe/server';
 import {
   calculateFeeBreakdown,
@@ -141,6 +142,7 @@ export async function releaseEscrowAndDistribute(
 
     // Record previous tenant transaction
     await db.insert(transactions).values({
+      id: randomUUID(),
       paymentId: escrowedPayments[0].id, // Link to first escrowed payment
       recipientType: 'seller',
       recipientId: property.userId,
@@ -151,6 +153,7 @@ export async function releaseEscrowAndDistribute(
 
     // Record platform fee transaction (no actual transfer, just record)
     await db.insert(transactions).values({
+      id: randomUUID(),
       paymentId: escrowedPayments[0].id,
       recipientType: 'platform',
       recipientId: null,

--- a/src/app/actions/payment.ts
+++ b/src/app/actions/payment.ts
@@ -1,5 +1,6 @@
 'use server';
 
+import { randomUUID } from 'crypto';
 import { stripe } from '@/lib/stripe/server';
 import { calculateDeposit, calculateFeeBreakdown } from '@/lib/stripe/server';
 import { STRIPE_CONFIG } from '@/lib/stripe/config';
@@ -75,6 +76,7 @@ export async function createApplicationFeePayment(
     const [payment] = await db
       .insert(payments)
       .values({
+        id: randomUUID(),
         propertyId,
         userId,
         type: 'application_fee',
@@ -156,6 +158,7 @@ export async function processApplicationFeeTransfer(
 
     // Record transaction in database
     await db.insert(transactions).values({
+      id: randomUUID(),
       paymentId: payment.id,
       recipientType: 'seller',
       recipientId: (payment.metadata as { previousTenantId?: string })
@@ -232,6 +235,7 @@ export async function createDepositPayment(
     const [payment] = await db
       .insert(payments)
       .values({
+        id: randomUUID(),
         propertyId,
         userId,
         type: 'deposit',
@@ -303,6 +307,7 @@ export async function createRemainingPayment(
     const [payment] = await db
       .insert(payments)
       .values({
+        id: randomUUID(),
         propertyId,
         userId,
         type: 'remaining',

--- a/src/app/actions/stripe-connect.ts
+++ b/src/app/actions/stripe-connect.ts
@@ -1,5 +1,6 @@
 'use server';
 
+import { randomUUID } from 'crypto';
 import { stripe } from '@/lib/stripe/server';
 import { db } from '@/db';
 import { stripeAccounts } from '@/db/schema';
@@ -46,6 +47,7 @@ export async function createConnectAccount(
 
     // Save to database
     await db.insert(stripeAccounts).values({
+      id: randomUUID(),
       userId,
       stripeAccountId: account.id,
       accountType: 'express',

--- a/src/lib/migrate-local-data.ts
+++ b/src/lib/migrate-local-data.ts
@@ -1,5 +1,6 @@
 'use server';
 
+import { randomUUID } from 'crypto';
 import { db } from '@/db';
 import { properties, inquiries } from '@/db/schema';
 import type { UserListing, Inquiry } from '@/lib/types';
@@ -22,6 +23,7 @@ export async function migrateLocalDataAction(
       for (const listing of localData.listings) {
         try {
           await db.insert(properties).values({
+            id: randomUUID(),
             userId,
             title: listing.title,
             images: listing.roomPhotos || [],
@@ -59,6 +61,7 @@ export async function migrateLocalDataAction(
           // For now, we'll skip inquiries that reference non-existent properties
           // In a real migration, you'd need to handle this more carefully
           await db.insert(inquiries).values({
+            id: randomUUID(),
             userId,
             propertyId: inquiry.propertyId,
             propertyTitle: inquiry.propertyTitle,


### PR DESCRIPTION
## Summary
- Add explicit ID generation using `crypto.randomUUID()` for all database inserts
- Required since schema now uses text IDs instead of auto-generated UUIDs
- Removes old NextAuth-related code from auth-actions.ts

## Changes
- `auth-actions.ts`: Add randomUUID import, add id field to sellerProfiles insert, remove old signUp/signIn functions
- `payment.ts`: Add randomUUID import, add id fields to payments and transactions inserts
- `escrow.ts`: Add randomUUID import, add id fields to transactions inserts
- `stripe-connect.ts`: Add randomUUID import, add id field to stripeAccounts insert
- `migrate-local-data.ts`: Add randomUUID import, add id fields to properties and inquiries inserts

## Test Plan
- [x] Build passes (`bun run build`)
- [x] Depends on PR #147 (already merged)
- [ ] Magic link authentication works end-to-end

Generated with Claude Code