### PR TITLE
feat(auth): migrate to better-auth library

### DIFF
--- a/src/app/api/auth/[...all]/route.ts
+++ b/src/app/api/auth/[...all]/route.ts
@@ -1,0 +1,4 @@
+import { auth } from '@/lib/auth';
+import { toNextJsHandler } from 'better-auth/next-js';
+
+export const { POST, GET } = toNextJsHandler(auth);

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,3 +1,0 @@
-import { handlers } from '@/lib/auth';
-
-export const { GET, POST } = handlers;

--- a/src/lib/auth-client.ts
+++ b/src/lib/auth-client.ts
@@ -1,0 +1,13 @@
+import { createAuthClient } from 'better-auth/react';
+import { magicLinkClient } from 'better-auth/client/plugins';
+
+export const authClient = createAuthClient({
+  baseURL:
+    typeof window !== 'undefined'
+      ? window.location.origin
+      : process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000',
+  plugins: [magicLinkClient()],
+});
+
+// Export convenience methods
+export const { signIn, signOut, useSession } = authClient;

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,146 +1,90 @@
-import NextAuth, { type DefaultSession } from 'next-auth';
-import { DrizzleAdapter } from '@auth/drizzle-adapter';
-import CredentialsProvider from 'next-auth/providers/credentials';
-import GoogleProvider from 'next-auth/providers/google';
+import { betterAuth } from 'better-auth';
+import { drizzleAdapter } from 'better-auth/adapters/drizzle';
+import { magicLink } from 'better-auth/plugins';
 import { db } from '@/db';
-import { users, accounts, sessions, verificationTokens } from '@/db/schema';
-import { compare } from 'bcryptjs';
-import { eq } from 'drizzle-orm';
+import * as schema from '@/db/schema';
 
-// Extend NextAuth types
-declare module 'next-auth' {
-  interface Session extends DefaultSession {
-    user: {
-      id: string;
-      isSeller: boolean;
-      isAdmin: boolean;
-    } & DefaultSession['user'];
-  }
+export const auth = betterAuth({
+  database: drizzleAdapter(db, {
+    provider: 'pg',
+    schema: {
+      user: schema.users,
+      session: schema.sessions,
+      account: schema.accounts,
+      verification: schema.verifications,
+    },
+  }),
 
-  interface User {
-    isSeller: boolean;
-    isAdmin: boolean;
-  }
-}
-
-export const { handlers, auth, signIn, signOut } = NextAuth({
-  // Type assertion needed due to version mismatch between @auth/drizzle-adapter and @auth/core
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  adapter: DrizzleAdapter(db, {
-    usersTable: users,
-    accountsTable: accounts,
-    sessionsTable: sessions,
-    verificationTokensTable: verificationTokens,
-  }) as any,
-
-  providers: [
-    CredentialsProvider({
-      name: 'Email',
-      credentials: {
-        email: { label: 'Email', type: 'email' },
-        password: { label: 'Password', type: 'password' },
-      },
-      async authorize(credentials) {
-        if (!credentials?.email || !credentials?.password) {
-          throw new Error('メールアドレスとパスワードを入力してください');
+  plugins: [
+    magicLink({
+      sendMagicLink: async ({ email, url }, request) => {
+        // Development mode: log to console
+        if (!process.env.RESEND_API_KEY) {
+          console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
+          console.log('🔗 Magic Link for:', email);
+          console.log('URL:', url);
+          console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
+          return;
         }
 
-        const email = credentials.email as string;
-        const password = credentials.password as string;
+        // Production mode: send via Resend
+        const { Resend } = await import('resend');
+        const resend = new Resend(process.env.RESEND_API_KEY);
 
-        // Find user by email
-        const user = await db.query.users.findFirst({
-          where: eq(users.email, email),
+        await resend.emails.send({
+          from: 'tsumugi <noreply@tsumugi.app>',
+          to: email,
+          subject: 'tsumugi ログインリンク',
+          html: `
+            <div style="font-family: sans-serif; max-width: 600px; margin: 0 auto;">
+              <h1 style="color: #FF5A5F;">tsumugi</h1>
+              <p>以下のリンクをクリックしてログインしてください：</p>
+              <a href="${url}" style="display: inline-block; padding: 12px 24px; background-color: #FF5A5F; color: white; text-decoration: none; border-radius: 8px;">
+                ログインする
+              </a>
+              <p style="margin-top: 24px; color: #666; font-size: 14px;">
+                このリンクは15分間有効です。リクエストしていない場合は無視してください。
+              </p>
+            </div>
+          `,
         });
-
-        if (!user || !user.passwordHash) {
-          throw new Error('メールアドレスまたはパスワードが正しくありません');
-        }
-
-        // Verify password
-        const isValid = await compare(password, user.passwordHash);
-
-        if (!isValid) {
-          throw new Error('メールアドレスまたはパスワードが正しくありません');
-        }
-
-        return {
-          id: user.id,
-          email: user.email,
-          name: user.name,
-          image: user.image,
-          isSeller: user.isSeller,
-          isAdmin: user.isAdmin || false,
-        };
       },
+      expiresIn: 60 * 15, // 15 minutes
     }),
-
-    // Google OAuth provider (optional)
-    ...(process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET
-      ? [
-          GoogleProvider({
-            clientId: process.env.GOOGLE_CLIENT_ID,
-            clientSecret: process.env.GOOGLE_CLIENT_SECRET,
-          }),
-        ]
-      : []),
   ],
 
+  user: {
+    additionalFields: {
+      isSeller: {
+        type: 'boolean',
+        defaultValue: false,
+      },
+      isAdmin: {
+        type: 'boolean',
+        defaultValue: false,
+      },
+      phone: {
+        type: 'string',
+        required: false,
+      },
+    },
+  },
+
   session: {
-    strategy: 'database',
-    maxAge: 30 * 24 * 60 * 60, // 30 days
-    updateAge: 24 * 60 * 60, // 24 hours
-  },
-
-  pages: {
-    signIn: '/', // Redirect to home page for sign in
-    error: '/', // Error page
-  },
-
-  callbacks: {
-    async session({ session, user }) {
-      if (session.user) {
-        session.user.id = user.id;
-
-        // Fetch latest user data to get isSeller and isAdmin
-        const dbUser = await db.query.users.findFirst({
-          where: eq(users.id, user.id),
-          columns: {
-            isSeller: true,
-            isAdmin: true,
-          },
-        });
-
-        session.user.isSeller = dbUser?.isSeller || false;
-        session.user.isAdmin = dbUser?.isAdmin || false;
-      }
-      return session;
-    },
-
-    async signIn({ user, account }) {
-      // For OAuth providers, update user info if needed
-      if (account?.provider === 'google' && user.email) {
-        const existingUser = await db.query.users.findFirst({
-          where: eq(users.email, user.email),
-        });
-
-        if (existingUser) {
-          // Update user's OAuth account if not already linked
-          return true;
-        }
-      }
-      return true;
+    expiresIn: 60 * 60 * 24 * 30, // 30 days
+    updateAge: 60 * 60 * 24, // 24 hours
+    cookieCache: {
+      enabled: true,
+      maxAge: 60 * 5, // 5 minutes
     },
   },
 
-  events: {
-    async signIn({ user }) {
-      console.log(`User signed in: ${user.email}`);
-    },
-    async signOut() {
-      console.log('User signed out');
-    },
-  },
-
-  debug: process.env.NODE_ENV === 'development',
+  trustedOrigins: [
+    'http://localhost:3000',
+    process.env.NEXT_PUBLIC_APP_URL || '',
+  ].filter(Boolean),
 });
+
+// Export types
+export type Session = typeof auth.$Infer.Session;
+export type User = typeof auth.$Infer.Session.user;


### PR DESCRIPTION
## Summary
- Replace NextAuth with better-auth for authentication
- Configure magic link authentication with Resend email
- Add client-side auth utilities

## Changes
- `src/lib/auth.ts`: better-auth server configuration with drizzle adapter
- `src/lib/auth-client.ts`: Client-side auth helper (new)
- `src/app/api/auth/[...all]/route.ts`: better-auth API route (new)
- `src/app/api/auth/[...nextauth]/route.ts`: Removed NextAuth route

## Test Plan
- [x] Build passes
- [ ] Magic link authentication works
- [ ] Session management works

Generated with Claude Code