### PR TITLE
chore: add .serena/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ playwright-results.json
 test-results/
 tests/e2e/artifacts/
 !tests/e2e/artifacts/.gitkeep
+.serena/


### PR DESCRIPTION
## Summary
- Add Serena MCP plugin directory to gitignore

## Changes
- `.gitignore`: Add `.serena/` entry

## Reason
`.serena/` contains local cache and session-specific AI context that shouldn't be committed to the repository.

Generated with Claude Code