### PR TITLE
chore(devcontainer): add resend domain to firewall

### DIFF
--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -75,6 +75,7 @@ for domain in \
     "update.code.visualstudio.com" \
     "main.vscode-cdn.net" \
     "api.linear.app" \
+    "api.resend.com" \
     "www.mensnonno.jp" \
     "pypi.org" \
     "files.pythonhosted.org" \


### PR DESCRIPTION
## Summary
- Add api.resend.com to firewall allowlist for email functionality (Magic Link auth)

## Changes
- Added `api.resend.com` to `.devcontainer/init-firewall.sh`

## Test Plan
- [ ] Verify devcontainer builds successfully
- [ ] Verify Resend API calls work from within devcontainer

Generated with Claude Code