### PR TITLE
fix(auth): use resend onboarding domain for emails

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -32,7 +32,7 @@ export const auth = betterAuth({
         const resend = new Resend(process.env.RESEND_API_KEY);
 
         await resend.emails.send({
-          from: 'tsumugi <noreply@tsumugi.app>',
+          from: 'tsumugi <onboarding@resend.dev>',
           to: email,
           subject: 'tsumugi ログインリンク',
           html: `


### PR DESCRIPTION
## Summary
- Update email sender address to use onboarding@resend.dev which is available by default
- Previous address noreply@tsumugi.app requires custom domain verification

## Changes
- Changed `from` field in magic link emails from `tsumugi <noreply@tsumugi.app>` to `tsumugi <onboarding@resend.dev>`

## Test Plan
- [ ] Verify magic link emails are sent successfully
- [ ] Verify email appears correctly in inbox

Generated with Claude Code