### PR TITLE
docs(rules): improve PR merge workflow with review checks and CI fix loop

### DIFF
--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -100,7 +100,7 @@ Note: Attribution disabled globally via ~/.claude/settings.json.
 1. Create/update PR
 2. Wait for CI checks (`gh pr checks`) - ALL must pass (lint, types, unit tests, E2E tests)
 3. If any CI check fails: use `/ralph-loop` to iteratively fix until all checks pass, then go back to step 2
-4. Check for PR review comments (`gh pr view <number> --comments` and `gh pr reviews <number>`)
+4. Check for PR review comments (`gh pr view <number> --comments` and `gh pr view <number> --json reviews`)
 5. If relevant comments exist: address them, push fixes, go back to step 2
 6. Merge PR (`gh pr merge <number> --squash --delete-branch`)
 7. Switch to main (`git checkout main`)
@@ -143,7 +143,7 @@ Note: Attribution disabled globally via ~/.claude/settings.json.
 **PR Review Comment Check (CRITICAL):**
 
 - **ALWAYS check for PR review comments before merging** using `gh pr view <number> --comments`
-- Also check review status: `gh pr reviews <number>`
+- Also check review status: `gh pr view <number> --json reviews`
 - Address ALL relevant review comments before merging, not just critical ones
 - Look for: requested changes, blocking reviews, bug reports, security concerns, design feedback, logic issues
 - Only skip comments that are clearly irrelevant (e.g., bot noise, outdated/resolved threads, pure style preferences with no substance)
@@ -184,7 +184,7 @@ When creating PRs:
 6. Verify PR contains only related changes
 7. **WAIT FOR ALL CI CHECKS TO PASS** - Use `gh pr checks` to monitor status (lint, types, unit tests, E2E)
 8. **If any CI check fails** - Use `/ralph-loop` to iteratively fix until green
-9. **CHECK FOR PR REVIEW COMMENTS** - Use `gh pr view <number> --comments` and `gh pr reviews <number>`
+9. **CHECK FOR PR REVIEW COMMENTS** - Use `gh pr view <number> --comments` and `gh pr view <number> --json reviews`
 10. **Address all relevant review comments** before proceeding
 11. **After ALL CI passes and review comments are addressed, merge PR with `gh pr merge <number> --squash --delete-branch`**
 12. **Switch back to main and delete local branch:**


### PR DESCRIPTION
## Summary
- Add mandatory PR review comment check before merging (all relevant comments, not just critical)
- Add iterative CI failure fixing using `/ralph-loop` (including E2E tests)
- Update all workflow sections to reflect the new pre-merge checks

## Changes
- Added "PR Review Comment Check" section requiring `gh pr view --comments` and `gh pr view --json reviews` before merge
- Changed CI check section to mandate ALL checks pass (lint, types, unit, E2E) with `/ralph-loop` for iterative fixing
- Updated Complete PR Workflow steps (now 9 steps with CI fix loop and review check)
- Updated worktree workflow, "When creating PRs" steps, and multiple-PR workflow to include both checks
- Flaky test escape hatch: flag to user rather than silently merging
- Fixed invalid `gh pr reviews` command to `gh pr view --json reviews` (caught by code review)

## Test Plan
- [ ] Verify markdown renders correctly
- [ ] Confirm all workflow sections are consistent with the new rules
- [ ] Verify all gh cli commands are valid

Generated with Claude Code