### PR TITLE
chore: replace npm/pnpm references with bun

### DIFF
--- a/.claude/agents/build-error-resolver.md
+++ b/.claude/agents/build-error-resolver.md
@@ -46,10 +46,10 @@ npx tsc --noEmit path/to/file.ts
 npx eslint . --ext .ts,.tsx,.js,.jsx
 
 # Next.js build (production)
-npm run build
+bun run build
 
 # Next.js build with debug
-npm run build -- --debug
+bun run build -- --debug
 ```
 
 ## Error Resolution Workflow
@@ -165,7 +165,7 @@ import { formatDate } from '@/lib/utils'
 import { formatDate } from '../lib/utils'
 
 // ✅ FIX 3: Install missing package
-npm install @/lib/utils
+bun install @/lib/utils
 ```
 
 **Pattern 5: Type Mismatch**
@@ -243,8 +243,8 @@ async function fetchData() {
 import React from 'react'
 
 // ✅ FIX: Install dependencies
-npm install react
-npm install --save-dev @types/react
+bun install react
+bun add -d @types/react
 
 // ✅ CHECK: Verify package.json has dependency
 {
@@ -453,10 +453,10 @@ Parameter 'market' implicitly has an 'any' type.
 ## Verification Steps
 
 1. ✅ TypeScript check passes: `npx tsc --noEmit`
-2. ✅ Next.js build succeeds: `npm run build`
+2. ✅ Next.js build succeeds: `bun run build`
 3. ✅ ESLint check passes: `npx eslint .`
 4. ✅ No new errors introduced
-5. ✅ Development server runs: `npm run dev`
+5. ✅ Development server runs: `bun run dev`
 
 ## Summary
 
@@ -477,7 +477,7 @@ Parameter 'market' implicitly has an 'any' type.
 ## When to Use This Agent
 
 **USE when:**
-- `npm run build` fails
+- `bun run build` fails
 - `npx tsc --noEmit` shows errors
 - Type errors blocking development
 - Import/module resolution errors
@@ -518,27 +518,27 @@ Parameter 'market' implicitly has an 'any' type.
 npx tsc --noEmit
 
 # Build Next.js
-npm run build
+bun run build
 
 # Clear cache and rebuild
 rm -rf .next node_modules/.cache
-npm run build
+bun run build
 
 # Check specific file
 npx tsc --noEmit src/path/to/file.ts
 
 # Install missing dependencies
-npm install
+bun install
 
 # Fix ESLint issues automatically
 npx eslint . --fix
 
 # Update TypeScript
-npm install --save-dev typescript@latest
+bun add -d typescript@latest
 
 # Verify node_modules
 rm -rf node_modules package-lock.json
-npm install
+bun install
 ````
 
 ## Success Metrics
@@ -546,7 +546,7 @@ npm install
 After build error resolution:
 
 - ✅ `npx tsc --noEmit` exits with code 0
-- ✅ `npm run build` completes successfully
+- ✅ `bun run build` completes successfully
 - ✅ No new errors introduced
 - ✅ Minimal lines changed (< 5% of affected file)
 - ✅ Build time not significantly increased

--- a/.claude/agents/doc-updater.md
+++ b/.claude/agents/doc-updater.md
@@ -255,7 +255,7 @@ Brief description
 
 # Installation
 
-npm install
+bun install
 
 # Environment variables
 
@@ -265,11 +265,11 @@ cp .env.example .env.local
 
 # Development
 
-npm run dev
+bun run dev
 
 # Build
 
-npm run build
+bun run build
 \`\`\`
 
 ## Architecture

--- a/.claude/agents/e2e-runner.md
+++ b/.claude/agents/e2e-runner.md
@@ -130,7 +130,7 @@ For each user journey:
 ```
 a) Run tests locally (in worktree)
    - Ensure you're in the worktree directory
-   - Start dev server: npm run dev
+   - Start dev server: bun run dev
    - Run tests: npx playwright test
    - Verify all tests pass
    - Check for flakiness (run 3-5 times)
@@ -507,7 +507,7 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: 'npm run dev',
+    command: 'bun run dev',
     url: 'http://localhost:3000',
     reuseExistingServer: !process.env.CI,
     timeout: 120000,
@@ -643,7 +643,7 @@ jobs:
           node-version: 18
 
       - name: Install dependencies
-        run: npm ci
+        run: bun install --frozen-lockfile
 
       - name: Install Playwright browsers
         run: npx playwright install --with-deps

--- a/.claude/agents/refactor-cleaner.md
+++ b/.claude/agents/refactor-cleaner.md
@@ -279,9 +279,9 @@ If something breaks after removal:
 
    ```bash
    git revert HEAD
-   npm install
-   npm run build
-   npm test
+   bun install
+   bun run build
+   bun run test
    ```
 
 2. **Investigate:**

--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -22,7 +22,7 @@ You are an expert security specialist focused on identifying and remediating vul
 
 ### Security Analysis Tools
 
-- **npm audit** - Check for vulnerable dependencies
+- **bun audit** - Check for vulnerable dependencies
 - **eslint-plugin-security** - Static analysis for security issues
 - **git-secrets** - Prevent committing secrets
 - **trufflehog** - Find secrets in git history
@@ -32,10 +32,10 @@ You are an expert security specialist focused on identifying and remediating vul
 
 ```bash
 # Check for vulnerable dependencies
-npm audit
+bun audit
 
 # High severity only
-npm audit --audit-level=high
+bun audit --audit-level=high
 
 # Check for secrets in files
 grep -r "api[_-]?key\|password\|secret\|token" --include="*.js" --include="*.ts" --include="*.json" .
@@ -56,7 +56,7 @@ git log -p | grep -i "password\|api_key\|secret"
 
 ```
 a) Run automated security tools
-   - npm audit for dependency vulnerabilities
+   - bun audit for dependency vulnerabilities
    - eslint-plugin-security for code issues
    - grep for hardcoded secrets
    - Check for exposed environment variables
@@ -118,7 +118,7 @@ For each category, check:
 
 9. Using Components with Known Vulnerabilities
    - Are all dependencies up to date?
-   - Is npm audit clean?
+   - Is bun audit clean?
    - Are CVEs monitored?
 
 10. Insufficient Logging & Monitoring
@@ -489,17 +489,17 @@ When reviewing PRs, post inline comments:
 
 ```bash
 # Install security linting
-npm install --save-dev eslint-plugin-security
+bun add -d eslint-plugin-security
 
 # Install dependency auditing
-npm install --save-dev audit-ci
+bun add -d audit-ci
 
 # Add to package.json scripts
 {
   "scripts": {
-    "security:audit": "npm audit",
+    "security:audit": "bun audit",
     "security:lint": "eslint . --plugin security",
-    "security:check": "npm run security:audit && npm run security:lint"
+    "security:check": "bun run security:audit && bun run security:lint"
   }
 }
 ```

--- a/.claude/agents/tdd-guide.md
+++ b/.claude/agents/tdd-guide.md
@@ -35,7 +35,7 @@ describe('searchMarkets', () => {
 ### Step 2: Run Test (Verify it FAILS)
 
 ```bash
-npm test
+bun run test
 # Test should fail - we haven't implemented yet
 ```
 
@@ -52,7 +52,7 @@ export async function searchMarkets(query: string) {
 ### Step 4: Run Test (Verify it PASSES)
 
 ```bash
-npm test
+bun run test
 # Test should now pass
 ```
 
@@ -66,7 +66,7 @@ npm test
 ### Step 6: Verify Coverage
 
 ```bash
-npm run test:coverage
+bun run test:coverage
 # Verify 80%+ coverage
 ```
 
@@ -280,7 +280,7 @@ test('updates user', () => {
 
 ```bash
 # Run tests with coverage
-npm run test:coverage
+bun run test:coverage
 
 # View HTML report
 open coverage/lcov-report/index.html
@@ -297,13 +297,13 @@ Required thresholds:
 
 ```bash
 # Watch mode during development
-npm test -- --watch
+bun run test -- --watch
 
 # Run before commit (via git hook)
-npm test && npm run lint
+bun run test && bun run lint
 
 # CI/CD integration
-npm test -- --coverage --ci
+bun run test -- --coverage --ci
 ```
 
 **Remember**: No code without tests. Tests are not optional. They are the safety net that enables confident refactoring, rapid development, and production reliability.

--- a/.claude/commands/build-fix.md
+++ b/.claude/commands/build-fix.md
@@ -2,7 +2,7 @@
 
 Incrementally fix TypeScript and build errors:
 
-1. Run build: npm run build or pnpm build
+1. Run build: bun run build
 
 2. Parse error output:
    - Group by file

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -47,24 +47,24 @@ Before pushing, verify all tests pass:
 1. **Run test suite**:
 
    ```bash
-   pnpm test
+   bun run test
    ```
 
 2. **Run type check**:
 
    ```bash
-   pnpm tsc --noEmit
+   bunx tsc --noEmit
    ```
 
 3. **Run linter**:
 
    ```bash
-   pnpm lint
+   bun run lint
    ```
 
 4. **Run build** (if applicable):
    ```bash
-   pnpm build
+   bun run build
    ```
 
 If any test fails:

--- a/.claude/commands/tdd.md
+++ b/.claude/commands/tdd.md
@@ -125,7 +125,7 @@ describe('calculateLiquidityScore', () => {
 ## Step 3: Run Tests - Verify FAIL
 
 ```bash
-npm test lib/liquidity.test.ts
+bun run test lib/liquidity.test.ts
 
 FAIL lib/liquidity.test.ts
   ✕ should return high score for liquid market (2 ms)
@@ -170,7 +170,7 @@ export function calculateLiquidityScore(market: MarketData): number {
 ## Step 5: Run Tests - Verify PASS
 
 ```bash
-npm test lib/liquidity.test.ts
+bun run test lib/liquidity.test.ts
 
 PASS lib/liquidity.test.ts
   ✓ should return high score for liquid market (3 ms)
@@ -239,7 +239,7 @@ export function calculateLiquidityScore(market: MarketData): number {
 ## Step 7: Verify Tests Still Pass
 
 ```bash
-npm test lib/liquidity.test.ts
+bun run test lib/liquidity.test.ts
 
 PASS lib/liquidity.test.ts
   ✓ should return high score for liquid market (3 ms)
@@ -254,7 +254,7 @@ PASS lib/liquidity.test.ts
 ## Step 8: Check Coverage
 
 ```bash
-npm test -- --coverage lib/liquidity.test.ts
+bun run test -- --coverage lib/liquidity.test.ts
 
 File           | % Stmts | % Branch | % Funcs | % Lines
 ---------------|---------|----------|---------|--------

--- a/.claude/commands/test-coverage.md
+++ b/.claude/commands/test-coverage.md
@@ -2,7 +2,7 @@
 
 Analyze test coverage and generate missing tests:
 
-1. Run tests with coverage: npm test --coverage or pnpm test --coverage
+1. Run tests with coverage: bun run test --coverage
 
 2. Analyze coverage report (coverage/coverage-summary.json)
 

--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -31,7 +31,7 @@ Working directly in the main workspace can lead to accidentally committing unrel
 
 ```bash
 # 1. Create worktree FIRST (before making any changes)
-npm run worktree:create <branch-name>
+bun run worktree:create <branch-name>
 
 # 2. Navigate to worktree
 cd /workspaces/tsumugi/.worktrees/<branch-name>

--- a/.claude/skills/project-guidelines-example.md
+++ b/.claude/skills/project-guidelines-example.md
@@ -256,13 +256,13 @@ async def test_health_check(client: AsyncClient):
 
 ```bash
 # Run tests
-npm run test
+bun run test
 
 # Run with coverage
-npm run test -- --coverage
+bun run test -- --coverage
 
 # Run E2E tests
-npm run test:e2e
+bun run test:e2e
 ```
 
 **Test structure:**
@@ -292,7 +292,7 @@ describe('WorkspacePanel', () => {
 ### Pre-Deployment Checklist
 
 - [ ] All tests passing locally
-- [ ] `npm run build` succeeds (frontend)
+- [ ] `bun run build` succeeds (frontend)
 - [ ] `poetry run pytest` passes (backend)
 - [ ] No hardcoded secrets
 - [ ] Environment variables documented
@@ -302,7 +302,7 @@ describe('WorkspacePanel', () => {
 
 ```bash
 # Build and deploy frontend
-cd frontend && npm run build
+cd frontend && bun run build
 gcloud run deploy frontend --source .
 
 # Build and deploy backend

--- a/.claude/skills/security-review/SKILL.md
+++ b/.claude/skills/security-review/SKILL.md
@@ -418,16 +418,16 @@ async function verifyTransaction(transaction: Transaction) {
 
 ```bash
 # Check for vulnerabilities
-npm audit
+bun audit
 
 # Fix automatically fixable issues
-npm audit fix
+bun audit fix
 
 # Update dependencies
-npm update
+bun update
 
 # Check for outdated packages
-npm outdated
+bun outdated
 ```
 
 #### Lock Files
@@ -437,13 +437,13 @@ npm outdated
 git add package-lock.json
 
 # Use in CI/CD for reproducible builds
-npm ci  # Instead of npm install
+bun install --frozen-lockfile  # Instead of npm install
 ```
 
 #### Verification Steps
 
 - [ ] Dependencies up to date
-- [ ] No known vulnerabilities (npm audit clean)
+- [ ] No known vulnerabilities (bun audit clean)
 - [ ] Lock files committed
 - [ ] Dependabot enabled on GitHub
 - [ ] Regular security updates

--- a/.claude/skills/tdd-workflow/SKILL.md
+++ b/.claude/skills/tdd-workflow/SKILL.md
@@ -90,7 +90,7 @@ describe('Semantic Search', () => {
 ### Step 3: Run Tests (They Should Fail)
 
 ```bash
-npm test
+bun run test
 # Tests should fail - we haven't implemented yet
 ```
 
@@ -108,7 +108,7 @@ export async function searchMarkets(query: string) {
 ### Step 5: Run Tests Again
 
 ```bash
-npm test
+bun run test
 # Tests should now pass
 ```
 
@@ -124,7 +124,7 @@ Improve code quality while keeping tests green:
 ### Step 7: Verify Coverage
 
 ```bash
-npm run test:coverage
+bun run test:coverage
 # Verify 80%+ coverage achieved
 ```
 
@@ -318,7 +318,7 @@ jest.mock('@/lib/openai', () => ({
 ### Run Coverage Report
 
 ```bash
-npm run test:coverage
+bun run test:coverage
 ```
 
 ### Coverage Thresholds
@@ -401,7 +401,7 @@ test('updates user', () => {
 ### Watch Mode During Development
 
 ```bash
-npm test -- --watch
+bun run test -- --watch
 # Tests run automatically on file changes
 ```
 
@@ -409,7 +409,7 @@ npm test -- --watch
 
 ```bash
 # Runs before every commit
-npm test && npm run lint
+bun run test && bun run lint
 ```
 
 ### CI/CD Integration
@@ -417,7 +417,7 @@ npm test && npm run lint
 ```yaml
 # GitHub Actions
 - name: Run Tests
-  run: npm test -- --coverage
+  run: bun run test -- --coverage
 - name: Upload Coverage
   uses: codecov/codecov-action@v3
 ```

--- a/.devcontainer/WORKTREE.md
+++ b/.devcontainer/WORKTREE.md
@@ -6,7 +6,7 @@ This guide explains how to use VS Code devcontainers when working with git workt
 
 ```bash
 # Create a new worktree with devcontainer support
-npm run worktree:create feature-name
+bun run worktree:create feature-name
 
 # Or manually (in devcontainer):
 git worktree add .worktrees/feature-name feature-name
@@ -38,7 +38,7 @@ When running inside a devcontainer, worktrees are created in a `.worktrees/` sub
 ### Option 1: Using the Helper Script (Recommended)
 
 ```bash
-npm run worktree:create my-feature
+bun run worktree:create my-feature
 ```
 
 This script:
@@ -184,7 +184,7 @@ ln -s ../tsumugi/.devcontainer .devcontainer
 
 ### Container uses old dependencies
 
-**Cause**: `postCreateCommand` runs `npm install` but package.json might differ across branches.
+**Cause**: `postCreateCommand` runs `bun install` but package.json might differ across branches.
 
 **Solution**: Rebuild the container:
 
@@ -230,7 +230,7 @@ ssh-add ~/.ssh/id_rsa
 
 This setup integrates with the project's git workflow defined in [.claude/rules/git-workflow.md](../.claude/rules/git-workflow.md):
 
-1. Create worktree for feature: `npm run worktree:create feature-auth`
+1. Create worktree for feature: `bun run worktree:create feature-auth`
 2. Open in VS Code and reopen in container
 3. Implement feature using TDD
 4. Commit changes: `/commit`
@@ -258,7 +258,7 @@ code .  # Opens in container instance 2
 Each container runs independently with its own:
 
 - Dev server (port 3000 + offset)
-- Dependencies (npm install per worktree)
+- Dependencies (bun install per worktree)
 - Git state (different branch checked out)
 
 ## References

--- a/.worktrees/README.md
+++ b/.worktrees/README.md
@@ -8,7 +8,7 @@ Worktrees created here are automatically ignored by git (see `.gitignore`).
 
 Create a new worktree:
 ```bash
-npm run worktree:create feature-name
+bun run worktree:create feature-name
 ```
 
 This directory is used instead of creating sibling directories to avoid permission issues in the devcontainer environment.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,13 +54,13 @@ bun run test:ui          # Run tests with Vitest UI
 bun run test:e2e         # Run E2E tests with Playwright
 
 # Git Worktrees (with devcontainer support)
-npm run worktree:create  # 新しいworktreeを作成 (still uses npm script runner)
-npm run worktree:list    # worktree一覧を表示
-npm run worktree:prune   # 削除済みworktreeをクリーンアップ
+bun run worktree:create  # 新しいworktreeを作成
+bun run worktree:list    # worktree一覧を表示
+bun run worktree:prune   # 削除済みworktreeをクリーンアップ
 
 # Branch Cleanup (automated)
-npm run cleanup:branches # マージ済みブランチと削除済みリモートブランチを削除
-npm run cleanup:all      # 完全クリーンアップ（ブランチ + worktree + stash）
+bun run cleanup:branches # マージ済みブランチと削除済みリモートブランチを削除
+bun run cleanup:all      # 完全クリーンアップ（ブランチ + worktree + stash）
 
 # Linear Integration (task tracking)
 ./scripts/linear-list.sh              # オープンタスクを一覧表示
@@ -145,7 +145,7 @@ bd ready                   # Check available work
 
 **Git Worktrees for Isolated Development**
 
-Use git worktrees (via Superpowers' `using-git-worktrees` skill or npm scripts) when:
+Use git worktrees (via Superpowers' `using-git-worktrees` skill or bun scripts) when:
 
 - Implementing complex features
 - Working from an implementation plan
@@ -165,9 +165,9 @@ Use git worktrees (via Superpowers' `using-git-worktrees` skill or npm scripts) 
 You can create worktrees manually with:
 
 ```bash
-npm run worktree:create feature-name  # Creates worktree with devcontainer support
-npm run worktree:list                 # List all worktrees
-npm run worktree:prune                # Clean up removed worktrees
+bun run worktree:create feature-name  # Creates worktree with devcontainer support
+bun run worktree:list                 # List all worktrees
+bun run worktree:prune                # Clean up removed worktrees
 ```
 
 Worktrees are created in `.worktrees/<branch-name>/` with automatic devcontainer symlink setup.
@@ -193,15 +193,15 @@ See [.devcontainer/WORKTREE.md](.devcontainer/WORKTREE.md) for detailed document
 **Local Cleanup Commands:**
 
 ```bash
-npm run cleanup:branches  # Delete merged and [gone] branches
-npm run cleanup:all       # Full cleanup: branches + worktrees + stashes
+bun run cleanup:branches  # Delete merged and [gone] branches
+bun run cleanup:all       # Full cleanup: branches + worktrees + stashes
 ```
 
 **Manual cleanup workflow:**
 
 ```bash
 git fetch --all --prune          # Update remote tracking
-npm run cleanup:branches         # Clean up branches
+bun run cleanup:branches         # Clean up branches
 git worktree prune               # Clean up worktrees
 ```
 
@@ -346,6 +346,7 @@ async function callClaude(prompt: string): Promise<string> {
 **GitHub Secret:** `ANTHROPIC_AUTH_TOKEN` - Your long-lived OAuth token from Max subscription
 
 **DO NOT use:**
+
 - `@anthropic-ai/sdk` with OAuth tokens (doesn't work)
 - `--no-config` flag (doesn't exist)
 - `ANTHROPIC_API_KEY` with OAuth tokens

--- a/README.md
+++ b/README.md
@@ -68,13 +68,13 @@ bun run test:run         # Run unit tests once and exit
 bun run test:e2e         # Run E2E tests with Playwright
 
 # Git Worktrees (for isolated development)
-npm run worktree:create  # Create new worktree with branch
-npm run worktree:list    # List all worktrees
-npm run worktree:prune   # Clean up removed worktrees
+bun run worktree:create  # Create new worktree with branch
+bun run worktree:list    # List all worktrees
+bun run worktree:prune   # Clean up removed worktrees
 
 # Branch Cleanup (automated)
-npm run cleanup:branches # Delete merged and [gone] branches
-npm run cleanup:all      # Full cleanup (branches + worktrees + stashes)
+bun run cleanup:branches # Delete merged and [gone] branches
+bun run cleanup:all      # Full cleanup (branches + worktrees + stashes)
 ```
 
 ## Development Tools
@@ -162,7 +162,7 @@ This project uses git worktrees for isolated development to prevent accidental f
 
 ```bash
 # Create worktree for new branch
-npm run worktree:create feature-name
+bun run worktree:create feature-name
 
 # Navigate to worktree
 cd .worktrees/feature-name
@@ -194,8 +194,8 @@ See `.devcontainer/WORKTREE.md` for detailed documentation.
 **Local cleanup:**
 
 ```bash
-npm run cleanup:branches  # Delete merged and [gone] branches
-npm run cleanup:all       # Full cleanup (branches + worktrees + stashes)
+bun run cleanup:branches  # Delete merged and [gone] branches
+bun run cleanup:all       # Full cleanup (branches + worktrees + stashes)
 ```
 
 ## Automated Workflows

--- a/docs/CONTRIB.md
+++ b/docs/CONTRIB.md
@@ -16,16 +16,19 @@ This guide covers the development workflow, tools, and best practices for contri
 ### Quick Start
 
 1. **Open in devcontainer**
+
    ```bash
    ./dev  # Opens VS Code devcontainer with Claude Code auto-started
    ```
 
 2. **Install dependencies** (if not already installed)
+
    ```bash
    bun install
    ```
 
 3. **Start development server**
+
    ```bash
    bun dev
    ```
@@ -38,6 +41,7 @@ This guide covers the development workflow, tools, and best practices for contri
 **Always use git worktrees to prevent accidental file inclusion in commits.**
 
 **When to use worktrees:**
+
 - ANY other modified files exist in your workspace
 - Making documentation updates
 - Implementing features or bug fixes
@@ -47,7 +51,7 @@ This guide covers the development workflow, tools, and best practices for contri
 
 ```bash
 # 1. Create worktree FIRST (before making changes)
-npm run worktree:create feature-name
+bun run worktree:create feature-name
 
 # 2. Navigate to worktree
 cd .worktrees/feature-name
@@ -85,74 +89,74 @@ See `.devcontainer/WORKTREE.md` for detailed documentation.
 
 ### Development
 
-| Command | Description |
-|---------|-------------|
-| `bun dev` | Start Next.js development server on http://localhost:3000 |
-| `bun run build` | Build production bundle with optimizations |
-| `bun start` | Start production server (requires `build` first) |
+| Command         | Description                                               |
+| --------------- | --------------------------------------------------------- |
+| `bun dev`       | Start Next.js development server on http://localhost:3000 |
+| `bun run build` | Build production bundle with optimizations                |
+| `bun start`     | Start production server (requires `build` first)          |
 
 ### Code Quality
 
-| Command | Description |
-|---------|-------------|
-| `bun lint` | Run ESLint and Prettier checks on all files |
-| `bun run format` | Auto-format all files with Prettier |
-| `bun run format:check` | Check formatting without making changes |
+| Command                | Description                                 |
+| ---------------------- | ------------------------------------------- |
+| `bun lint`             | Run ESLint and Prettier checks on all files |
+| `bun run format`       | Auto-format all files with Prettier         |
+| `bun run format:check` | Check formatting without making changes     |
 
 ### Testing
 
-| Command | Description |
-|---------|-------------|
-| `bun test` | Run unit tests with Vitest |
+| Command           | Description                    |
+| ----------------- | ------------------------------ |
+| `bun test`        | Run unit tests with Vitest     |
 | `bun run test:ui` | Run Vitest with interactive UI |
 
 #### E2E Testing (Playwright)
 
-| Command | Description |
-|---------|-------------|
-| `bun run test:e2e` | Run all E2E tests headless |
-| `bun run test:e2e:headed` | Run E2E tests with browser visible |
-| `bun run test:e2e:debug` | Run E2E tests in debug mode with Playwright Inspector |
-| `bun run test:e2e:ui` | Run E2E tests with Playwright UI mode |
-| `bun run test:e2e:report` | Show HTML test report from last run |
+| Command                   | Description                                           |
+| ------------------------- | ----------------------------------------------------- |
+| `bun run test:e2e`        | Run all E2E tests headless                            |
+| `bun run test:e2e:headed` | Run E2E tests with browser visible                    |
+| `bun run test:e2e:debug`  | Run E2E tests in debug mode with Playwright Inspector |
+| `bun run test:e2e:ui`     | Run E2E tests with Playwright UI mode                 |
+| `bun run test:e2e:report` | Show HTML test report from last run                   |
 
 #### E2E Test Tag Filtering
 
-| Command | Description |
-|---------|-------------|
-| `bun run test:e2e:critical` | Run only critical path tests (smoke + auth + checkout) |
-| `bun run test:e2e:smoke` | Run smoke tests (basic functionality) |
-| `bun run test:e2e:auth` | Run authentication tests |
-| `bun run test:e2e:listing` | Run listing creation tests |
-| `bun run test:e2e:properties` | Run property browsing tests |
+| Command                       | Description                                            |
+| ----------------------------- | ------------------------------------------------------ |
+| `bun run test:e2e:critical`   | Run only critical path tests (smoke + auth + checkout) |
+| `bun run test:e2e:smoke`      | Run smoke tests (basic functionality)                  |
+| `bun run test:e2e:auth`       | Run authentication tests                               |
+| `bun run test:e2e:listing`    | Run listing creation tests                             |
+| `bun run test:e2e:properties` | Run property browsing tests                            |
 
 ### Git Worktrees
 
-| Command | Description |
-|---------|-------------|
-| `npm run worktree:create` | Create new worktree with devcontainer support |
-| `npm run worktree:list` | List all worktrees |
-| `npm run worktree:prune` | Clean up removed worktrees |
+| Command                   | Description                                   |
+| ------------------------- | --------------------------------------------- |
+| `bun run worktree:create` | Create new worktree with devcontainer support |
+| `bun run worktree:list`   | List all worktrees                            |
+| `bun run worktree:prune`  | Clean up removed worktrees                    |
 
 ### Branch Cleanup
 
-| Command | Description |
-|---------|-------------|
-| `npm run cleanup:branches` | Delete merged and [gone] branches |
-| `npm run cleanup:all` | Full cleanup (branches + worktrees + stashes) |
+| Command                    | Description                                   |
+| -------------------------- | --------------------------------------------- |
+| `bun run cleanup:branches` | Delete merged and [gone] branches             |
+| `bun run cleanup:all`      | Full cleanup (branches + worktrees + stashes) |
 
 ### Git Hooks
 
-| Command | Description |
-|---------|-------------|
+| Command           | Description                              |
+| ----------------- | ---------------------------------------- |
 | `bun run prepare` | Configure git hooks path to `.githooks/` |
 
 ### Devcontainer
 
-| Command | Description |
-|---------|-------------|
-| `./dev` | Open devcontainer with Claude Code (auto-starts) |
-| `bun run shell` | Alias for `./dev` |
+| Command         | Description                                      |
+| --------------- | ------------------------------------------------ |
+| `./dev`         | Open devcontainer with Claude Code (auto-starts) |
+| `bun run shell` | Alias for `./dev`                                |
 
 ## Environment Setup
 
@@ -326,10 +330,12 @@ bun run test:e2e:report
 **CI/CD Integration:**
 
 E2E tests run automatically on:
+
 - Every PR
 - Every push to main branch
 
 Test reports are published to GitHub Pages:
+
 - https://kokiebisu.github.io/tsumugi/e2e-reports/
 
 ### Test Coverage
@@ -341,6 +347,7 @@ bun test --coverage
 ```
 
 **Minimum requirements:**
+
 - **Overall:** 80%+ coverage
 - **Unit tests:** All utilities, functions, components
 - **Integration tests:** API endpoints, database operations
@@ -359,6 +366,7 @@ Follow Conventional Commits:
 ```
 
 **Types:**
+
 - `feat:` - New feature
 - `fix:` - Bug fix
 - `refactor:` - Code refactoring
@@ -399,6 +407,7 @@ docs: update contributing guide
 **Auto-merge after CI (default):**
 
 Merge immediately after CI passes for:
+
 - Docs updates
 - Config changes
 - Bug fixes (small, non-breaking)
@@ -408,6 +417,7 @@ Merge immediately after CI passes for:
 - Dependency updates
 
 **Wait for user approval only for:**
+
 - Breaking changes affecting existing APIs
 - Major architectural decisions
 - Large features (10+ files)
@@ -425,10 +435,10 @@ Merge immediately after CI passes for:
 
 ```bash
 # Delete merged and [gone] branches
-npm run cleanup:branches
+bun run cleanup:branches
 
 # Full cleanup (branches + worktrees + stashes)
-npm run cleanup:all
+bun run cleanup:all
 ```
 
 ## Code Quality

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -96,13 +96,13 @@ Before deploying the application, ensure all database migrations are applied:
 
 ```bash
 # Install dependencies
-npm install
+bun install
 
 # Generate migration files (if not already generated)
-npm run db:generate
+bun run db:generate
 
 # Apply migrations to production database
-npm run db:migrate
+bun run db:migrate
 ```
 
 #### Option B: Using Drizzle Studio
@@ -112,7 +112,7 @@ npm run db:migrate
 export DATABASE_URL="postgresql://[user]:[password]@[host]/[db]?sslmode=require"
 
 # Open Drizzle Studio
-npm run db:studio
+bun run db:studio
 
 # Verify schema matches expected structure
 ```
@@ -244,7 +244,7 @@ railway up
 1. Configure environment variables in platform dashboard
 2. Build application:
    ```bash
-   npm run build
+   bun run build
    ```
 3. Start production server:
    ```bash
@@ -527,7 +527,7 @@ Set up alerts for critical events:
 2. **Re-run migrations**:
 
    ```bash
-   npm run db:migrate
+   bun run db:migrate
    ```
 
 3. **Check database schema**:
@@ -599,7 +599,7 @@ vercel rollback [deployment-url]
 
 ```bash
 # Revert migrations (if needed)
-npm run db:rollback
+bun run db:rollback
 
 # Or manually drop tables
 psql $DATABASE_URL

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "worktree:list": "git worktree list",
     "worktree:prune": "git worktree prune",
     "cleanup:branches": "bash scripts/cleanup-branches.sh",
-    "cleanup:all": "npm run cleanup:branches && git worktree prune && git stash clear"
+    "cleanup:all": "bun run cleanup:branches && git worktree prune && git stash clear"
   },
   "dependencies": {
     "@auth/core": "^0.41.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -36,7 +36,7 @@ export default defineConfig({
 
   /* Run local dev server before tests */
   webServer: {
-    command: process.env.CI ? 'npm run start' : 'npm run dev',
+    command: process.env.CI ? 'bun run start' : 'bun run dev',
     url: 'http://localhost:3000',
     reuseExistingServer: !process.env.CI,
     timeout: 120000,


### PR DESCRIPTION
## Summary

- Standardize all package manager command references from npm/pnpm to bun across the entire codebase
- Covers code/config files, documentation, agent templates, skill definitions, and command files
- Keeps `npm install -g` for global CLI installs in GitHub Actions (intentional)

## Changes

**Code/Config (2 files):**
- `package.json` - internal script reference (`cleanup:all`)
- `playwright.config.ts` - E2E test webServer command

**Primary Documentation (3 files):**
- `CLAUDE.md` - worktree/cleanup commands, removed stale "(still uses npm script runner)" comment
- `README.md` - worktree/cleanup commands
- `.claude/rules/git-workflow.md` - worktree:create command

**Secondary Documentation (5 files):**
- `.devcontainer/WORKTREE.md` - worktree commands, install references
- `docs/CONTRIB.md` - contributing guide commands
- `.worktrees/README.md` - quick example
- `docs/DEPLOYMENT.md` - install/build/run commands (kept `npm install -g` for global tools)
- `.claude/commands/build-fix.md` - build command

**Agent/Skill Templates (9 files):**
- 6 agent files: build-error-resolver, tdd-guide, e2e-runner, doc-updater, refactor-cleaner, security-reviewer
- 3 skill files: tdd-workflow, project-guidelines-example, security-review

**Extra files found during verification (3 files):**
- `.claude/commands/tdd.md`, `test-coverage.md`, `pr.md` - pnpm/npm test/tsc/lint/build references

## Mapping Applied

| Before | After |
|--------|-------|
| `npm run <script>` | `bun run <script>` |
| `npm install` | `bun install` |
| `npm install --save-dev <pkg>` | `bun add -d <pkg>` |
| `npm ci` | `bun install --frozen-lockfile` |
| `npm test` | `bun run test` |
| `npm audit/update/outdated` | `bun audit/update/outdated` |
| `pnpm test/tsc/lint/build` | `bun run test` / `bunx tsc` / `bun run lint` / `bun run build` |

## Test Plan

- [x] `bun run test:run` - 65 tests pass (6 test files)
- [x] `bunx tsc --noEmit` - no type errors
- [x] `bun run lint` - only pre-existing warnings (unrelated to changes)
- [x] Grep verification: no remaining npm/pnpm command references (except intentional `npm install -g` and archived docs/plans)

Generated with Claude Code