### PR TITLE
chore: migrate devcontainer to docker-compose with services

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -111,7 +111,9 @@ COPY init-firewall.sh /usr/local/bin/
 USER root
 RUN chmod +x /usr/local/bin/init-firewall.sh && \
   echo "bun ALL=(root) NOPASSWD: /usr/local/bin/init-firewall.sh" > /etc/sudoers.d/bun-firewall && \
-  chmod 0440 /etc/sudoers.d/bun-firewall
+  chmod 0440 /etc/sudoers.d/bun-firewall && \
+  echo "bun ALL=(root) NOPASSWD: /bin/chgrp docker /var/run/docker.sock" > /etc/sudoers.d/bun-docker && \
+  chmod 0440 /etc/sudoers.d/bun-docker
 USER bun
 
 # Install Beads CLI (bd) for AI-friendly task tracking

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,10 +2,9 @@
   "name": "Bun & TypeScript",
   // This devcontainer config is shared across git worktrees via symlinks
   // See WORKTREE.md for details on using devcontainers with git worktrees
-  "build": {
-    "dockerfile": "Dockerfile"
-  },
-  "runArgs": ["--cap-add=NET_ADMIN", "--cpus=6"],
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "app",
+  "workspaceFolder": "/workspace",
   "customizations": {
     "vscode": {
       "extensions": [
@@ -14,7 +13,9 @@
         "esbenp.prettier-vscode",
         "ms-vscode.vscode-typescript-next",
         "eamodio.gitlens",
-        "GitHub.vscode-github-actions"
+        "GitHub.vscode-github-actions",
+        "ms-azuretools.vscode-containers",
+        "ms-playwright.playwright"
       ],
       "settings": {
         "editor.formatOnSave": true,
@@ -22,8 +23,8 @@
       }
     }
   },
-  "forwardPorts": [3000, 9323],
-  "postCreateCommand": "bun install && git config --global worktree.guessRemote true && ([ -d .beads ] || bd init --quiet) && echo \"alias claude='claude --skip-dangerously-permission'\" >> ~/.bashrc",
+  "forwardPorts": [3000, 4566, 5432, 9323],
+  "postCreateCommand": "bun install && bunx playwright install chromium && git config --global worktree.guessRemote true && ([ -d .beads ] || bd init --quiet) && echo \"alias claude='claude --dangerously-skip-permissions'\" >> ~/.bashrc && echo \"alias claude='claude --dangerously-skip-permissions'\" >> ~/.zshrc",
   "remoteUser": "bun",
   "postAttachCommand": ".devcontainer/install-plugins.sh",
   "mounts": [
@@ -39,6 +40,6 @@
   "containerEnv": {
     "CLAUDE_CONFIG_DIR": "/home/bun/.claude"
   },
-  "postStartCommand": "sudo /usr/local/bin/init-firewall.sh",
+  "postStartCommand": "sudo chgrp docker /var/run/docker.sock && sudo /usr/local/bin/init-firewall.sh",
   "waitFor": "postStartCommand"
 }

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,54 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - ..:/workspace:cached
+    command: sleep infinity
+    cap_add:
+      - NET_ADMIN
+    deploy:
+      resources:
+        limits:
+          cpus: "6"
+
+  postgres:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    network_mode: service:app
+    environment:
+      POSTGRES_USER: tsumugi
+      POSTGRES_PASSWORD: tsumugi
+      POSTGRES_DB: tsumugi
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U tsumugi"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    depends_on:
+      - app
+
+  localstack:
+    image: localstack/localstack:latest
+    network_mode: service:app
+    environment:
+      - SERVICES=s3
+      - DEBUG=0
+      - DEFAULT_REGION=ap-northeast-1
+    volumes:
+      - "../scripts/localstack-init.sh:/etc/localstack/init/ready.d/init.sh"
+      - localstack_data:/var/lib/localstack
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:4566/_localstack/health"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    depends_on:
+      - app
+
+volumes:
+  postgres_data:
+  localstack_data:

--- a/scripts/localstack-init.sh
+++ b/scripts/localstack-init.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+echo "Creating S3 bucket for tsumugi..."
+awslocal s3 mb s3://tsumugi
+echo "Bucket created successfully."


### PR DESCRIPTION
## Summary

- Switch devcontainer from standalone Dockerfile to docker-compose setup
- Add Postgres, LocalStack S3, and Docker-in-Docker services for local development
- Add Playwright browser and container management extensions

## Changes

- `.devcontainer/docker-compose.yml` - New compose file with app (Dockerfile), postgres (16-alpine), and localstack services
- `.devcontainer/Dockerfile` - Add Docker socket group permissions for DinD support
- `.devcontainer/devcontainer.json` - Use `dockerComposeFile` instead of `build`, add ports 4566/5432, add Playwright/Docker extensions, install Playwright chromium in postCreateCommand, fix claude alias flag
- `scripts/localstack-init.sh` - Script to create S3 bucket in LocalStack

## Test Plan

- [ ] `./dev` opens devcontainer successfully with docker-compose
- [ ] Postgres service is reachable on port 5432
- [ ] LocalStack S3 is reachable on port 4566
- [ ] Docker socket is accessible inside the container
- [ ] Playwright chromium is installed during postCreateCommand

Generated with Claude Code