### PR TITLE
fix: correct linear-done.sh query and build-error-resolver install cmd

### DIFF
--- a/.claude/agents/build-error-resolver.md
+++ b/.claude/agents/build-error-resolver.md
@@ -244,7 +244,7 @@ import React from 'react'
 
 // ✅ FIX: Install dependencies
 bun install react
-bun add -d @types/react
+bun install --save-dev @types/react
 
 // ✅ CHECK: Verify package.json has dependency
 {
@@ -534,7 +534,7 @@ bun install
 npx eslint . --fix
 
 # Update TypeScript
-bun add -d typescript@latest
+bun install --save-dev typescript@latest
 
 # Verify node_modules
 rm -rf node_modules package-lock.json

--- a/scripts/linear-done.sh
+++ b/scripts/linear-done.sh
@@ -49,12 +49,12 @@ echo ""
 for IDENTIFIER in "$@"; do
   echo "Processing $IDENTIFIER..."
 
-  # Get issue ID from identifier
+  # Get issue ID from identifier (using issue() query which accepts TSU-XXX format)
   ISSUE_ID=$(curl -s -X POST \
     -H "Content-Type: application/json" \
     -H "Authorization: $LINEAR_API_KEY" \
-    -d "{\"query\":\"query { issues(filter: { identifier: { eq: \\\"$IDENTIFIER\\\" } }) { nodes { id identifier title state { name } } } }\"}" \
-    https://api.linear.app/graphql | python3 -c "import sys, json; data=json.load(sys.stdin); nodes=data['data']['issues']['nodes']; print(nodes[0]['id'] if nodes else '')")
+    -d "{\"query\":\"query { issue(id: \\\"$IDENTIFIER\\\") { id identifier title state { name } } }\"}" \
+    https://api.linear.app/graphql | python3 -c "import sys, json; data=json.load(sys.stdin); issue=data.get('data',{}).get('issue'); print(issue['id'] if issue else '')")
 
   if [ -z "$ISSUE_ID" ]; then
     echo "  ❌ Issue $IDENTIFIER not found"


### PR DESCRIPTION
## Summary

- Fix linear-done.sh to use the correct Linear API query for issue lookup
- Revert build-error-resolver agent to use `bun install --save-dev` for consistency

## Changes

- `scripts/linear-done.sh` - Use `issue(id: "TSU-XXX")` query instead of `issues(filter: { identifier: { eq: "TSU-XXX" } })` which doesn't work for identifier-based lookup
- `.claude/agents/build-error-resolver.md` - Change `bun add -d` back to `bun install --save-dev` in example commands for consistency with common usage

## Test Plan

- [ ] `./scripts/linear-done.sh TSU-XXX` successfully marks tasks as done
- [ ] Agent examples show correct install commands

Generated with Claude Code