### PR TITLE
chore: add GitGuardian config to ignore local dev credentials

### DIFF
--- a/.gitguardian.yaml
+++ b/.gitguardian.yaml
@@ -1,0 +1,8 @@
+version: 2
+
+secret:
+  # Docker Compose files contain local development credentials only
+  # (e.g., POSTGRES_PASSWORD: tsumugi) - not real secrets
+  ignored_paths:
+    - 'docker-compose.yml'
+    - '.devcontainer/docker-compose.yml'


### PR DESCRIPTION
## Summary

- Add `.gitguardian.yaml` to exclude Docker Compose files from secret scanning
- Fixes false positive GitGuardian failures on PRs #166 and #167 where local dev passwords (`POSTGRES_PASSWORD: tsumugi`) were flagged as hardcoded secrets

## Changes

- `.gitguardian.yaml` - New config (version 2) with `ignored_paths` for `docker-compose.yml` and `.devcontainer/docker-compose.yml`

## Context

PRs #166 and #167 were merged with failing GitGuardian checks - this was a mistake. The GitGuardian failures were false positives (local development-only Postgres passwords), but CI failures should have been resolved before merging. This PR prevents the false positives going forward.

## Test Plan

- [ ] Future PRs touching docker-compose files should pass GitGuardian checks
- [ ] GitGuardian still scans all other files normally

Generated with Claude Code