### PR TITLE
chore: update env example for R2 and local postgres

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,8 @@
-# Database Configuration (Neon PostgreSQL)
-# Get this from Neon dashboard: https://neon.tech
-DATABASE_URL="postgresql://[user]:[password]@[host]/[db]?sslmode=require"
+# Database Configuration
+# For local development (Docker Compose):
+DATABASE_URL="postgresql://tsumugi:tsumugi@localhost:5432/tsumugi"
+# For Neon (production):
+# DATABASE_URL="postgresql://[user]:[password]@[host].neon.tech/[db]?sslmode=require"
 
 # NextAuth.js Configuration
 # Generate a secret: openssl rand -base64 32
@@ -16,12 +18,17 @@ GOOGLE_CLIENT_SECRET=""
 APPLE_CLIENT_ID=""
 APPLE_CLIENT_SECRET=""
 
-# AWS S3 Configuration (Optional - for image storage)
-# AWS Console: https://console.aws.amazon.com/
-AWS_ACCESS_KEY_ID=""
-AWS_SECRET_ACCESS_KEY=""
-AWS_REGION="ap-northeast-1"
-AWS_S3_BUCKET_NAME="tsumugi-images"
+# Image Storage (Cloudflare R2 in production, LocalStack locally)
+# R2 Dashboard: https://dash.cloudflare.com/
+R2_ACCOUNT_ID=""
+R2_ACCESS_KEY_ID=""
+R2_SECRET_ACCESS_KEY=""
+R2_BUCKET_NAME="tsumugi"
+R2_PUBLIC_URL=""
+
+# Local development: set this to use LocalStack instead of R2
+# LocalStack starts automatically with the devcontainer
+S3_ENDPOINT="http://localhost:4566"
 
 # Email Provider (Optional - for notifications)
 # Resend: https://resend.com/


### PR DESCRIPTION
## Summary
- Replace AWS S3 configuration with Cloudflare R2 variables (`R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`, etc.)
- Add `S3_ENDPOINT` for LocalStack local development
- Update default `DATABASE_URL` to local Docker Compose postgres

## Changes
- `.env.example`: Replaced AWS S3 section with R2 config, added LocalStack endpoint, updated DB URL default

## Test Plan
- [ ] Verify `.env.example` documents all required variables
- [ ] Confirm local development works with LocalStack endpoint
- [ ] Validate R2 variables match production config expectations

Generated with Claude Code