### PR TITLE
chore: make Playwright browser install on-demand

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -46,8 +46,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   python3-pip \
   && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Install Playwright system dependencies (using bunx instead of npx)
-RUN bunx -y playwright@1.58.0 install-deps chromium
+# Install Playwright system dependencies only (requires root, small footprint ~50MB)
+# Browser binary installed on-demand via: bun run test:e2e:install
+RUN npx playwright install-deps chromium
 
 # Add bun user to docker group for Docker socket access
 RUN groupadd -f docker && usermod -aG docker bun

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -24,7 +24,7 @@
     }
   },
   "forwardPorts": [3000, 4566, 5432, 9323],
-  "postCreateCommand": "bun install && bunx playwright install chromium && git config --global worktree.guessRemote true && ([ -d .beads ] || bd init --quiet) && echo \"alias claude='claude --dangerously-skip-permissions'\" >> ~/.bashrc && echo \"alias claude='claude --dangerously-skip-permissions'\" >> ~/.zshrc",
+  "postCreateCommand": "bun install && git config --global worktree.guessRemote true && ([ -d .beads ] || bd init --quiet) && echo \"alias claude='claude --dangerously-skip-permissions'\" >> ~/.bashrc && echo \"alias claude='claude --dangerously-skip-permissions'\" >> ~/.zshrc",
   "remoteUser": "bun",
   "postAttachCommand": ".devcontainer/install-plugins.sh",
   "mounts": [


### PR DESCRIPTION
## Summary
- Install only Playwright system dependencies (shared libs ~50MB) in the Docker image
- Remove automatic Chromium browser binary download from `postCreateCommand`
- Browser binary is now installed on-demand via `bun run test:e2e:install`
- Keeps the devcontainer image ~300MB leaner for sessions that don't run E2E tests

## Changes
- `.devcontainer/Dockerfile`: Use `npx playwright install-deps chromium` for system deps only, with clarifying comments
- `.devcontainer/devcontainer.json`: Remove `bunx playwright install chromium` from `postCreateCommand`

## Test Plan
- [ ] Rebuild devcontainer and verify it starts successfully
- [ ] Run `bun run test:e2e:install` to install Chromium on-demand
- [ ] Run `bun run test:e2e` to verify E2E tests work after on-demand install

Generated with Claude Code