### PR TITLE
chore: enable --dangerously-skip-permissions in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,7 +19,8 @@
       ],
       "settings": {
         "editor.formatOnSave": true,
-        "editor.defaultFormatter": "esbenp.prettier-vscode"
+        "editor.defaultFormatter": "esbenp.prettier-vscode",
+        "claude-code.terminalCommandFlags": "--dangerously-skip-permissions"
       }
     }
   },


### PR DESCRIPTION
## Summary
- Adds `claude-code.terminalCommandFlags: "--dangerously-skip-permissions"` to devcontainer VS Code settings
- Allows Claude Code to run without permission prompts inside the devcontainer

## Test plan
- [ ] Rebuild devcontainer and verify Claude Code runs with skip-permissions flag