### PR TITLE
chore: improve devcontainer config

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -48,7 +48,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Install Playwright system dependencies only (requires root, small footprint ~50MB)
 # Browser binary installed on-demand via: bun run test:e2e:install
-RUN npx playwright install-deps chromium
+RUN bunx playwright install-deps chromium
 
 # Add bun user to docker group for Docker socket access
 RUN groupadd -f docker && usermod -aG docker bun

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "name": "Bun & TypeScript",
+  "name": "Workspace",
   // This devcontainer config is shared across git worktrees via symlinks
   // See WORKTREE.md for details on using devcontainers with git worktrees
   "dockerComposeFile": "docker-compose.yml",
@@ -20,7 +20,8 @@
       "settings": {
         "editor.formatOnSave": true,
         "editor.defaultFormatter": "esbenp.prettier-vscode",
-        "claude-code.terminalCommandFlags": "--dangerously-skip-permissions"
+        "claude-code.terminalCommandFlags": "--dangerously-skip-permissions",
+        "telemetry.telemetryLevel": "off"
       }
     }
   },


### PR DESCRIPTION
## Summary
- Use `bunx` instead of `npx` for Playwright dependency install in Dockerfile (consistent with Bun runtime)
- Rename container from "Bun & TypeScript" to "Workspace"
- Disable VS Code telemetry to suppress `EHOSTUNREACH` errors on container startup

## Changes
- `.devcontainer/Dockerfile`: `npx` → `bunx` for playwright install-deps
- `.devcontainer/devcontainer.json`: Updated name, added `"telemetry.telemetryLevel": "off"`

## Test Plan
- [ ] Devcontainer builds successfully
- [ ] No telemetry errors in devcontainer logs
- [ ] Playwright E2E setup still works (`bun run test:e2e:install`)

Generated with Claude Code