### PR TITLE
chore: add Serena MCP tool permission to project settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,5 +11,8 @@
     "serena@claude-plugins-official": true,
     "context7@claude-plugins-official": true,
     "superpowers@claude-plugins-official": true
+  },
+  "permissions": {
+    "allow": ["mcp__plugin_serena_serena__get_symbols_overview"]
   }
 }


### PR DESCRIPTION
## Summary
- Adds `permissions.allow` for the Serena MCP `get_symbols_overview` tool in project-level `.claude/settings.json`

## Changes
- `.claude/settings.json`: Added `permissions` block with allowed MCP tool

## Test Plan
- [ ] Verify Claude Code picks up the permission without prompting
- [ ] Confirm no other settings are affected

Generated with Claude Code