### PR TITLE
chore: allow all MCP tool permissions in project settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,6 +13,6 @@
     "superpowers@claude-plugins-official": true
   },
   "permissions": {
-    "allow": ["mcp__plugin_serena_serena__get_symbols_overview"]
+    "allow": ["mcp__*"]
   }
 }


### PR DESCRIPTION
## Summary
- Broadens MCP tool permissions from a single Serena tool to all MCP tools (`mcp__*`)
- Eliminates permission prompts for any MCP server tool

## Changes
- `.claude/settings.json`: Changed `permissions.allow` from `["mcp__plugin_serena_serena__get_symbols_overview"]` to `["mcp__*"]`

## Test Plan
- [ ] Verify all MCP tools run without permission prompts
- [ ] Confirm no other settings are affected

Generated with Claude Code