### PR TITLE
chore: allow all Bash commands in project settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,6 +13,6 @@
     "superpowers@claude-plugins-official": true
   },
   "permissions": {
-    "allow": ["mcp__*"]
+    "allow": ["mcp__*", "Bash(*)"]
   }
 }


### PR DESCRIPTION
## Summary
- Adds `Bash(*)` to project permissions allow list so all Bash commands run without prompting

## Changes
- `.claude/settings.json`: Added `Bash(*)` to `permissions.allow` array

## Test Plan
- [ ] Verify Bash commands execute without permission prompts
- [ ] Confirm no other settings are affected

Generated with Claude Code