### PR TITLE
docs: add Section 18 technical decisions and Stripe Connect Phase 4 to roadmap

### DIFF
--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -1023,3 +1023,105 @@ tsumugiの決済システムは、次の住人から前の住人・大家・管�
 | 8   | ~~MVP期の「手動決済」の具体像がない~~                                               | 7            | **解決済み** — Stripe Connect Destination Chargesで実装。tsumugiが資金を預からない構造。エスクロー解放のみMVPでは管理者手動トリガー（セクション12.7参照）         | トモヤ                     |
 | 9   | ~~クリーニングのタイミングがフローに組み込まれていない~~                            | 7→8          | **解決済み** — ステップ8「退去・クリーニング」を追加（8ステップ→9ステップ化）。管理会社が手配、費用は引越し費用から充当                                           | ユキ                       |
 | 10  | ~~鍵の受け渡し・入居日の調整方法が未定義~~                                          | 8→9          | **解決済み** — 管理会社の通常業務（シリンダー交換→新しい鍵付与）。tsumugiの関与不要                                                                               | ユキ                       |
+
+---
+
+## 18. 技術的残論点（要検討）
+
+MVP実装に向けて技術選定が必要な項目。`/meeting:tech`（技術会議）で議論・決定する。
+
+| #   | 残論点                       | 決定                                                                                                 | 関連機能            | ステータス                                                                |
+| --- | ---------------------------- | ---------------------------------------------------------------------------------------------------- | ------------------- | ------------------------------------------------------------------------- |
+| T-1 | PDF自動生成の技術選定        | **`@react-pdf/renderer`** — サーバーサイド`renderToBuffer()` + R2保存。日本語フォント: Noto Sans JP  | F-611, F-612, F-616 | **解決済み** — 技術会議（2026-02-06）で決定                               |
+| T-2 | メール送信サービスの技術選定 | **Resend + React Email** — 導入済み（Better-auth magic linkで使用中）。MVP無料枠（3,000通/月）で十分 | F-204, F-205        | **解決済み** — 技術会議（2026-02-06）で決定                               |
+| T-3 | 定期実行（Cron）の技術選定   | **Vercel Cron Jobs** — `vercel.json`にcron定義。毎日実行でリマインドチェック + 期限切れチェック      | F-205, F-206        | **解決済み** — 技術会議（2026-02-06）で決定                               |
+| T-4 | DBスキーマ拡張               | **Drizzleマイグレーション** — `landlordConsent`をJSONB構造化、`moveOutDate`等のフィールド追加        | F-501, F-611        | **解決済み** — 技術会議（2026-02-06）で決定。実装時にマイグレーション実行 |
+
+### 18.2 技術決定の詳細
+
+#### T-1: PDF自動生成アーキテクチャ
+
+```
+[リスティングデータ]
+  → API Route (POST /api/pdf/generate)
+  → @react-pdf/renderer (サーバーサイド renderToBuffer())
+  → PDFバイナリ生成
+  → R2にアップロード（永続保存）
+  → URLをPropertyレコードに保存
+```
+
+**テンプレート配置:** `src/lib/pdf/templates/` に F-611・F-612・F-616 それぞれ別テンプレート
+**日本語フォント:** Noto Sans JP（public/fonts/ に配置 or CDN動的ロード）
+**実装優先順位:** F-611 + F-616（同時）→ F-612
+
+#### T-2: メール送信アーキテクチャ
+
+**テンプレート配置:** `src/lib/email/templates/` に React Email コンポーネント
+
+| メール種別         | トリガー         | 宛先     | Reply-to           | 機能ID |
+| ------------------ | ---------------- | -------- | ------------------ | ------ |
+| 問い合わせ確認     | 問い合わせ送信時 | 次の住人 | —                  | F-204  |
+| 新着問い合わせ通知 | 問い合わせ送信時 | 前の住人 | 問い合わせ者メアド | F-204  |
+| 承認リマインド     | 出品後7/14/21日  | 前の住人 | —                  | F-205  |
+| 自動非公開化通知   | 出品後30日       | 前の住人 | —                  | F-206  |
+
+#### T-3: Vercel Cron Jobs設定
+
+```json
+{
+  "crons": [
+    { "path": "/api/cron/reminder-check", "schedule": "0 0 * * *" },
+    { "path": "/api/cron/expiration-check", "schedule": "0 1 * * *" }
+  ]
+}
+```
+
+**リマインドチェック（毎日0:00 UTC）:** 退去日確定済み + pending状態のリスティングを検索 → 7/14/21日経過でメール送信
+**期限切れチェック（毎日1:00 UTC）:** 30日経過のpendingリスティングを自動非公開化 + 通知メール
+
+#### T-4: DBスキーマ拡張（Drizzleマイグレーション）
+
+| 変更内容                          | テーブル   | 説明                                   |
+| --------------------------------- | ---------- | -------------------------------------- |
+| `moveOutDate` 追加                | properties | 退去日（nullable Date）                |
+| `managementCompanyName` 追加      | properties | 管理会社名（nullable string）          |
+| `managementConsultedAt` 追加      | properties | 管理会社相談日時（nullable timestamp） |
+| `landlordConsent` をJSONBに構造化 | properties | boolean → ConsentStatus構造体          |
+| `pdfUrls` 追加                    | properties | 生成済みPDFのR2 URL格納（JSONB）       |
+| `agreedFurniture` 追加            | inquiries  | 確定家具リスト（string[]）             |
+| `duration` 追加                   | inquiries  | 希望契約期間（string）                 |
+
+### 18.3 MVP実装ロードマップ（技術会議合意）
+
+```
+Phase 0: インフラ整備（1週間）
+├── DBスキーマ拡張（moveOutDate, landlordConsent構造化等）
+├── Resendメールテンプレート基盤
+└── @react-pdf/renderer セットアップ + 日本語フォント + POC検証
+
+Phase 1: コア機能強化（2週間）
+├── F-501/F-502: 退去日フィールド + バリデーション
+├── 大家承認ステータス表示（バッジ・バナー 5パターン）
+├── F-204: 問い合わせ通知メール（Resend）
+└── F-701: 使い方ガイドページ（静的ページ）
+
+Phase 2: PDF + B2B（2-3週間）
+├── F-611: 残置物引き継ぎ相談資料PDF
+├── F-616: 仲介向け物件シートPDF
+├── F-615: 管理会社向けFAQ（静的ページ）
+└── PDF生成トリガー（退去日設定時に自動生成）
+
+Phase 3: 自動化（1週間）
+├── F-205: 承認リマインド通知（Vercel Cron + Resend）
+├── F-206: 承認期限切れ自動処理（Vercel Cron）
+└── F-612: 残置物同意書PDF（家具リスト確定時）
+
+Phase 4: 決済基盤 — Stripe Connect（2-3週間）
+├── Stripe Connectプラットフォーム設定（APIキー・Webhook endpoint・環境変数）
+├── 前の住人オンボーディングフロー（出品時にConnected Account作成 + Stripe Hosted Onboarding）
+├── 決済UI（3段階チェックアウト: 申込金→デポジット→残額）
+├── Webhook処理（payment_intent.succeeded, account.updated, transfer.created等）
+└── 管理者エスクロー解放（手動トリガーのAdmin画面 — 引き継ぎ完了確認後に実行）
+
+合計: 約8-10週間
+```


### PR DESCRIPTION
## Summary

- Add Section 18 (技術的残論点) with technical decisions from tech meetings (T-1 through T-4: PDF, Email, Cron, DB schema)
- Add MVP implementation roadmap (Phase 0-4) including **Phase 4: Stripe Connect** (2-3 weeks)
- Phase 4 covers: platform setup, seller onboarding, 3-stage payment UI, webhooks, admin escrow release

## Roadmap overview

```
Phase 0: Infrastructure (1w)
Phase 1: Core features (2w)
Phase 2: PDF + B2B (2-3w)
Phase 3: Automation (1w)
Phase 4: Stripe Connect (2-3w)  ← NEW
Total: ~8-10 weeks
```

## Test plan

- [ ] Verify REQUIREMENTS.md renders correctly
- [ ] Verify Section 18 cross-references are consistent
- [ ] Verify Phase 4 aligns with Section 12.7 MVP implementation policy