### PR TITLE
docs: update Section 9 tech stack to reflect decisions

### DIFF
--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -557,23 +557,27 @@ booleanではなく構造化データとして管理。条件付き承認や原�
 
 ### 9.1 フロントエンド
 
-| 分類             | 技術                                                         |
-| ---------------- | ------------------------------------------------------------ |
-| フレームワーク   | Next.js 16 (App Router)                                      |
-| 言語             | TypeScript 5                                                 |
-| UIライブラリ     | React 19                                                     |
-| スタイリング     | Tailwind CSS 3                                               |
-| UIコンポーネント | shadcn/ui (Radix UI)                                         |
-| アイコン         | Lucide React                                                 |
-| フォーム         | React Hook Form + Zod                                        |
-| PDF生成          | @react-pdf/renderer（サーバーサイド生成も可）※技術選定は別途 |
-| メール送信       | Resend or SendGrid（問い合わせ通知 F-204）※技術選定は別途    |
+| 分類             | 技術                                                            |
+| ---------------- | --------------------------------------------------------------- |
+| フレームワーク   | Next.js 16 (App Router)                                         |
+| 言語             | TypeScript 5                                                    |
+| UIライブラリ     | React 19                                                        |
+| スタイリング     | Tailwind CSS 3                                                  |
+| UIコンポーネント | shadcn/ui (Radix UI)                                            |
+| アイコン         | Lucide React                                                    |
+| フォーム         | React Hook Form + Zod                                           |
+| PDF生成          | @react-pdf/renderer（サーバーサイド renderToBuffer() + R2保存） |
+| メール送信       | Resend + React Email（問い合わせ通知 F-204、リマインド F-205）  |
+| 定期実行         | Vercel Cron Jobs（リマインドチェック、期限切れチェック）        |
+| 決済             | Stripe Connect — Destination Charges（Phase 4）                 |
+| ORM              | Drizzle ORM                                                     |
+| 認証             | Better Auth（magic link）                                       |
 
 ### 9.2 開発環境
 
 | 分類                 | 技術                  |
 | -------------------- | --------------------- |
-| パッケージマネージャ | npm                   |
+| パッケージマネージャ | Bun                   |
 | コンテナ             | Docker + DevContainer |
 | リンター             | ESLint                |
 | コード整形           | Prettier              |


### PR DESCRIPTION
## Summary
- Section 9.1 の技術スタックを技術会議（2026-02-06）の決定内容に更新
- 古い「※技術選定は別途」注記を削除し、確定した技術を反映

## Changes
- **PDF生成**: `@react-pdf/renderer ... ※技術選定は別途` → `@react-pdf/renderer（サーバーサイド renderToBuffer() + R2保存）`
- **メール送信**: `Resend or SendGrid ... ※技術選定は別途` → `Resend + React Email`
- **パッケージマネージャ**: `npm` → `Bun`（実態に合わせて修正）
- **新規追加**: 定期実行（Vercel Cron Jobs）、決済（Stripe Connect）、ORM（Drizzle）、認証（Better Auth）

## Rationale
技術会議でT-1〜T-4が全て決定済みにもかかわらず、Section 9.1が古い暫定記述のままだった（課題A）。

## Test plan
- [ ] Section 9.1 に「※技術選定は別途」が残っていないこと
- [ ] 全技術が技術会議の決定内容と一致していること