### PR TITLE
docs: add handoverFee field to Property data model

### DIFF
--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -443,6 +443,7 @@ MVPリリース後、利用実績に応じて段階的に追加する機能群�
 | faq                   | FAQ[]               | -    | よくある質問（下記7.5参照）                                      |
 | coordinatorId         | string              | -    | コーディネーターのユーザーID                                     |
 | landlordConsent       | LandlordConsent     | ○    | 大家承認情報（下記7.4参照）                                      |
+| handoverFee           | number              | ○    | 引越し費用（円）。内訳はセクション12.3参照                       |
 | moveOutDate           | Date \| null        | ○    | 退去（引き渡し）予定日                                           |
 | managementCompanyName | string              | -    | 管理会社名（前の住人が入力。ポストのシール・管理アプリ等で確認） |
 | managementConsultedAt | Date \| null        | -    | 管理会社に残置物相談を行った日時（前の住人が自己申告）           |


### PR DESCRIPTION
## Summary
- Add missing `handoverFee` (引越し費用) field to Section 7.1 Property data model
- This field is a core concept (defined in Section 12.3) and already exists in code (`src/lib/data.ts:234`)
- Cross-references Section 12.3 for fee breakdown details

## Changes
- `docs/REQUIREMENTS.md`: Added `handoverFee | number | ○` row to Section 7.1 Property table

## Test plan
- [x] Verify field is correctly placed in the table
- [x] Verify cross-reference to Section 12.3 is accurate
- [x] Verify alignment with existing code (`Property.handoverFee` in `src/lib/data.ts`)