### PR TITLE
chore: fix beads command in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,7 +98,7 @@ Use the `bd` command for AI-friendly task tracking instead of markdown TODOs:
 bd ready              # Show tasks with no blockers
 bd create "Task"      # Create new task
 bd status --json      # Get JSON output for agents
-bd done <id>          # Mark task complete
+bd close <id>         # Mark task complete
 bd show <id>          # Show task details and dependencies
 ```
 


### PR DESCRIPTION
## Summary
- Fix incorrect beads CLI command: `bd done` → `bd close`
- Auto-formatted quote style in next-env.d.ts

## Changes
- `CLAUDE.md`: Updated beads command reference from `bd done` to `bd close`
- `next-env.d.ts`: Quote style auto-format (single → double quotes)

## Test Plan
- [ ] Verify `bd close <id>` command works correctly
- [ ] Build passes

Generated with Claude Code