### PR TITLE
feat: add moveOutDate field to listing form (F-501)

### DIFF
--- a/src/app/listing/new/page.tsx
+++ b/src/app/listing/new/page.tsx
@@ -26,6 +26,7 @@ import {
   Tv,
   Refrigerator,
   Users,
+  CalendarDays,
 } from 'lucide-react';
 
 // 間取りの選択肢
@@ -76,6 +77,7 @@ export default function NewListingPage() {
   const [location, setLocation] = useState<LocationWithAddress | null>(null);
   const [managementFee, setManagementFee] = useState<string>('');
   const [selectedFurniture, setSelectedFurniture] = useState<string[]>([]);
+  const [moveOutDate, setMoveOutDate] = useState<Date | null>(null);
   const [viewingDate, setViewingDate] = useState<Date | null>(null);
   const [viewingEndDate, setViewingEndDate] = useState<Date | null>(null);
   const [moveInDate, setMoveInDate] = useState<Date | null>(null);
@@ -179,6 +181,9 @@ export default function NewListingPage() {
           selectedFurniture.length > 0
             ? (selectedFurniture as LargeFurnitureType[])
             : undefined,
+        moveOutDate: moveOutDate
+          ? moveOutDate.toISOString().split('T')[0]
+          : undefined,
         viewingAvailableFrom: formatDateRange(viewingDate, viewingEndDate),
         moveInAvailableFrom: formatDateRange(moveInDate, moveInEndDate),
         stations: stations
@@ -222,6 +227,9 @@ export default function NewListingPage() {
           selectedFurniture.length > 0
             ? (selectedFurniture as LargeFurnitureType[])
             : undefined,
+        moveOutDate: moveOutDate
+          ? moveOutDate.toISOString().split('T')[0]
+          : undefined,
         viewingAvailableFrom: formatDateRange(viewingDate, viewingEndDate),
         moveInAvailableFrom: formatDateRange(moveInDate, moveInEndDate),
         stations: stations
@@ -247,7 +255,7 @@ export default function NewListingPage() {
       case 4:
         return rent.length > 0 && layout.length > 0;
       case 5:
-        return true; // スケジュールは任意
+        return moveOutDate !== null; // 退去日は必須（F-501）
       case 6:
         return selectedFurniture.length > 0 && handoverFee.length > 0;
       default:
@@ -597,6 +605,26 @@ export default function NewListingPage() {
               </p>
 
               <div className="w-full space-y-8">
+                {/* 退去日（必須） */}
+                <div>
+                  <SingleDatePicker
+                    selectedDate={moveOutDate}
+                    endDate={null}
+                    onDateChange={(start) => {
+                      setMoveOutDate(start);
+                    }}
+                    title={
+                      moveOutDate
+                        ? `退去日: ${moveOutDate.toLocaleDateString('ja-JP', { year: 'numeric', month: 'long', day: 'numeric' })}`
+                        : '退去予定日を選択（必須）'
+                    }
+                    subtitle={
+                      moveOutDate ? undefined : '現在の住居を退去する予定日'
+                    }
+                    minDate={new Date()}
+                  />
+                </div>
+
                 {/* 内見可能日 */}
                 <div>
                   <SingleDatePicker
@@ -934,12 +962,29 @@ export default function NewListingPage() {
                 </section>
 
                 {/* 引き継ぎスケジュール */}
-                {(viewingDate || moveInDate) && (
+                {(moveOutDate || viewingDate || moveInDate) && (
                   <section className="py-8">
                     <h3 className="mb-6 text-xl font-semibold text-foreground">
                       引き継ぎスケジュール
                     </h3>
                     <div className="space-y-4">
+                      {moveOutDate && (
+                        <div className="flex items-start gap-3">
+                          <CalendarDays className="h-5 w-5 text-muted-foreground mt-0.5 flex-shrink-0" />
+                          <div>
+                            <p className="text-sm text-muted-foreground">
+                              退去予定日
+                            </p>
+                            <p className="text-base font-semibold text-foreground">
+                              {moveOutDate.toLocaleDateString('ja-JP', {
+                                year: 'numeric',
+                                month: 'long',
+                                day: 'numeric',
+                              })}
+                            </p>
+                          </div>
+                        </div>
+                      )}
                       {viewingDate && (
                         <div className="flex items-start gap-3">
                           <Tv className="h-5 w-5 text-muted-foreground mt-0.5 flex-shrink-0" />

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -212,6 +212,7 @@ export interface UserListing {
   area?: string; // エリア
   layout?: string; // 間取り
   occupants?: number; // 居住人数
+  moveOutDate?: string; // 退去日（F-501）
   viewingAvailableFrom?: string; // 内見可能日
   moveInAvailableFrom?: string; // 引き継ぎ可能日
   stations?: { name: string; walkingMinutes: number }[]; // 最寄り駅（複数）
@@ -246,6 +247,7 @@ export interface Property {
   occupancy?: number; // 居住人数
   style?: string; // e.g., "scandinavian", "industrial", "bohemian", "minimal", "vintage", "modern", etc.
   furniture?: LargeFurnitureType[]; // 引き継ぎ対象の大型家具
+  moveOutDate?: string; // 退去日（F-501）
   status: 'draft' | 'public';
   // 以下は詳細ページ用（MVP後に追加検討）
   summary?: string;
@@ -307,6 +309,7 @@ export const properties: Property[] = [
     ],
     furnitureDescription:
       'ヴィンテージのチェスト、手作りの本棚、レコードプレーヤー。壁にかかる大きなタペストリーはお気に入りのアーティストの作品。スケートボードやアート作品もそのままお使いいただけます。',
+    moveOutDate: '2026-03-01',
     status: 'public',
     story:
       'グラフィックデザイナーとして活動しながら、この部屋を自分だけのギャラリーのように育ててきました。窓辺の植物たちに水をやり、好きなレコードをかけながら作業する日々。海外での仕事が決まり、この空間を大切にしてくれる方に引き継ぎたいと思っています。',
@@ -413,6 +416,7 @@ export const properties: Property[] = [
       'DJとして活動しながら、週末は自宅でイベントを開催してきました。コンクリートの音響と、機材を囲んだ空間が最高です。海外ツアーが決まり、同じように音楽を愛する方に使ってもらえたら嬉しいです。レコードコレクションも一部そのまま使えます。',
     conditions:
       '音楽制作をする方歓迎。深夜の音出しOK（防音済み）。機材の扱いに慣れている方優先。',
+    moveOutDate: '2026-02-28',
     handoverFee: 60000,
     rent: 120000,
     managementFee: 8000,
@@ -519,6 +523,7 @@ export const properties: Property[] = [
     story:
       '古着屋を営みながら、仕事帰りに少しずつ集めた家具たち。この部屋で過ごす時間が一番落ち着きます。店舗を移転することになり、この空間を気に入ってくれる方に譲りたいです。',
     conditions: 'ヴィンテージ品を大切にしてくれる方。喫煙不可。',
+    moveOutDate: '2026-05-15',
     handoverFee: 48000,
     rent: 75000,
     managementFee: 5000,


### PR DESCRIPTION
## Summary

- Add `moveOutDate` field to `UserListing` and `Property` interfaces in `src/lib/data.ts`
- Add required `SingleDatePicker` for move-out date in step 5 of listing creation form
- Step 5 validation now requires `moveOutDate` before user can proceed (previously optional)
- Display selected `moveOutDate` in confirmation step 7
- Save `moveOutDate` (ISO date string) in both publish and draft save flows
- Add `moveOutDate` values to 3 mock properties for testing badge/sort features

Implements **F-501** (退去日フィールド) from REQUIREMENTS.md v1.9.

## Test plan

- [ ] Navigate to /listing/new and proceed to step 5
- [ ] Verify "退去予定日を選択（必須）" picker is displayed before viewing/move-in pickers
- [ ] Verify "次へ" button is disabled until moveOutDate is selected
- [ ] Select a date and verify it displays correctly in the picker title
- [ ] Proceed to step 7 and verify moveOutDate shows in confirmation under "引き継ぎスケジュール"
- [ ] Publish listing and verify moveOutDate is saved

🤖 Generated with [Claude Code](https://claude.com/claude-code)