### PR TITLE
feat: add urgent move-in badge for properties (F-507)

### DIFF
--- a/src/app/listings/[id]/page.tsx
+++ b/src/app/listings/[id]/page.tsx
@@ -26,6 +26,8 @@ import {
   Coffee,
   Users,
 } from 'lucide-react';
+import { isUrgentMoveIn } from '@/lib/utils';
+import { UrgentMoveInBadge } from '@/components/urgent-move-in-badge';
 
 const FURNITURE_ICONS: Record<string, typeof BedDouble> = {
   bed: BedDouble,
@@ -102,9 +104,14 @@ export default async function PropertyDetailPage({
             <div className="lg:col-span-3">
               {/* Title and Location */}
               <div className="pb-6 border-b border-border">
-                <h1 className="text-[26px] font-medium text-foreground">
-                  {property.title}
-                </h1>
+                <div className="flex items-center gap-2 flex-wrap">
+                  <h1 className="text-[26px] font-medium text-foreground">
+                    {property.title}
+                  </h1>
+                  {isUrgentMoveIn(property.moveOutDate) && (
+                    <UrgentMoveInBadge variant="inline" />
+                  )}
+                </div>
                 <p className="mt-1 text-base font-normal text-foreground">
                   {[
                     property.location?.neighborhood || property.area,

--- a/src/components/property-card.tsx
+++ b/src/components/property-card.tsx
@@ -7,6 +7,8 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { Heart, ChevronLeft, ChevronRight } from 'lucide-react';
 import type { Property } from '@/lib/data';
+import { isUrgentMoveIn } from '@/lib/utils';
+import { UrgentMoveInBadge } from '@/components/urgent-move-in-badge';
 
 function parseLocation(neighborhood: string | undefined): {
   ward?: string;
@@ -70,6 +72,9 @@ export function PropertyCard({ property }: PropertyCardProps) {
           onLoad={() => setImageLoaded(true)}
           priority={false}
         />
+
+        {/* 即入居可能バッジ（F-507） */}
+        {isUrgentMoveIn(property.moveOutDate) && <UrgentMoveInBadge />}
 
         {/* Heart button */}
         <button

--- a/src/components/urgent-move-in-badge.tsx
+++ b/src/components/urgent-move-in-badge.tsx
@@ -1,0 +1,38 @@
+import { Zap } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface UrgentMoveInBadgeProps {
+  className?: string;
+  variant?: 'overlay' | 'inline';
+}
+
+export function UrgentMoveInBadge({
+  className,
+  variant = 'overlay',
+}: UrgentMoveInBadgeProps) {
+  if (variant === 'overlay') {
+    return (
+      <div
+        className={cn(
+          'absolute left-3 top-3 z-10 flex items-center gap-1 rounded-full bg-coral px-2.5 py-1 text-xs font-semibold text-white shadow-md',
+          className
+        )}
+      >
+        <Zap className="h-3 w-3" />
+        即入居可能
+      </div>
+    );
+  }
+
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-1 rounded-full bg-red-50 px-2.5 py-1 text-xs font-semibold text-coral',
+        className
+      )}
+    >
+      <Zap className="h-3 w-3" />
+      即入居可能
+    </span>
+  );
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,25 @@ import { twMerge } from 'tailwind-merge';
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+/**
+ * 退去日までの残り日数を計算
+ */
+export function getDaysUntilMoveOut(moveOutDate: string): number {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const moveOut = new Date(moveOutDate);
+  moveOut.setHours(0, 0, 0, 0);
+  return Math.ceil(
+    (moveOut.getTime() - today.getTime()) / (1000 * 60 * 60 * 24)
+  );
+}
+
+/**
+ * 即入居可能かどうか判定（退去日が30日以内）
+ */
+export function isUrgentMoveIn(moveOutDate: string | undefined): boolean {
+  if (!moveOutDate) return false;
+  const days = getDaysUntilMoveOut(moveOutDate);
+  return days >= 0 && days <= 30;
+}


### PR DESCRIPTION
## Summary

- Create `UrgentMoveInBadge` component with two variants:
  - **overlay**: Coral badge with lightning icon, positioned on property card images
  - **inline**: Lighter coral badge shown next to text (e.g., detail page title)
- Add shared utility functions `isUrgentMoveIn()` and `getDaysUntilMoveOut()` in `src/lib/utils.ts`
- Display badge on property cards when `moveOutDate` is within 30 days
- Display inline badge next to title on property detail page

Implements **F-507** (「即入居可能」ラベル) from REQUIREMENTS.md v1.9.

## Test plan

- [ ] Properties with `moveOutDate` within 30 days show coral "即入居可能" badge on card image
- [ ] Properties without `moveOutDate` or > 30 days away show no badge
- [ ] Property detail page shows inline badge next to title for urgent properties
- [ ] Badge styling matches Airbnb-style coral theme (`#FF5A5F`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)