### PR TITLE
feat: add Phase 0 Zod validation schemas

### DIFF
--- a/src/app/api/properties/[id]/route.ts
+++ b/src/app/api/properties/[id]/route.ts
@@ -5,6 +5,7 @@ const z = zod;
 import { auth } from '@/lib/auth';
 import { db } from '@/db';
 import { properties } from '@/db/schema';
+import { furnitureItemSchema, landlordConsentSchema } from '@/lib/validations';
 
 const updatePropertySchema = z.object({
   title: z.string().min(1).max(500).optional(),
@@ -23,26 +24,10 @@ const updatePropertySchema = z.object({
   layout: z.string().max(50).optional().nullable(),
   occupancy: z.number().int().nonnegative().optional().nullable(),
   style: z.string().max(50).optional().nullable(),
-  furnitureItems: z.array(z.any()).optional().nullable(),
+  furnitureItems: z.array(furnitureItemSchema).optional().nullable(),
   condition: z.enum(['excellent', 'good', 'used']).optional().nullable(),
   estimatedDuration: z.string().max(50).optional().nullable(),
-  landlordConsent: z
-    .object({
-      status: z.enum([
-        'pending',
-        'approved',
-        'conditional',
-        'rejected',
-        'expired',
-      ]),
-      approvedItems: z.array(z.string()).optional(),
-      rejectedItems: z.array(z.string()).optional(),
-      conditions: z.string().optional(),
-      restorationTerms: z.string().optional(),
-      approvedAt: z.string().optional(),
-      approvedBy: z.string().optional(),
-    })
-    .optional(),
+  landlordConsent: landlordConsentSchema.optional(),
   amenities: z.array(z.string()).optional().nullable(),
   furnitureDescription: z.string().optional().nullable(),
   story: z.string().optional().nullable(),

--- a/src/app/api/properties/route.ts
+++ b/src/app/api/properties/route.ts
@@ -5,6 +5,7 @@ const z = zod;
 import { auth } from '@/lib/auth';
 import { db } from '@/db';
 import { properties } from '@/db/schema';
+import { furnitureItemSchema, landlordConsentSchema } from '@/lib/validations';
 
 const createPropertySchema = z.object({
   title: z.string().min(1, 'タイトルは必須です').max(500),
@@ -22,26 +23,10 @@ const createPropertySchema = z.object({
   layout: z.string().max(50).optional(),
   occupancy: z.number().int().nonnegative().optional(),
   style: z.string().max(50).optional(),
-  furnitureItems: z.array(z.any()).optional(),
+  furnitureItems: z.array(furnitureItemSchema).optional(),
   condition: z.enum(['excellent', 'good', 'used']).optional(),
   estimatedDuration: z.string().max(50).optional(),
-  landlordConsent: z
-    .object({
-      status: z.enum([
-        'pending',
-        'approved',
-        'conditional',
-        'rejected',
-        'expired',
-      ]),
-      approvedItems: z.array(z.string()).optional(),
-      rejectedItems: z.array(z.string()).optional(),
-      conditions: z.string().optional(),
-      restorationTerms: z.string().optional(),
-      approvedAt: z.string().optional(),
-      approvedBy: z.string().optional(),
-    })
-    .default({ status: 'pending' }),
+  landlordConsent: landlordConsentSchema.default({ status: 'pending' }),
   amenities: z.array(z.string()).optional(),
   furnitureDescription: z.string().optional(),
   story: z.string().optional(),

--- a/src/lib/validations/__tests__/inquiry.test.ts
+++ b/src/lib/validations/__tests__/inquiry.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { inquiryFieldsSchema } from '../inquiry';
+
+describe('inquiryFieldsSchema', () => {
+  it('accepts empty object (all optional)', () => {
+    expect(inquiryFieldsSchema.parse({})).toEqual({});
+  });
+
+  it('accepts valid duration', () => {
+    const result = inquiryFieldsSchema.parse({ duration: '6ヶ月' });
+    expect(result.duration).toBe('6ヶ月');
+  });
+
+  it('rejects duration exceeding 100 characters', () => {
+    expect(() =>
+      inquiryFieldsSchema.parse({ duration: 'a'.repeat(101) })
+    ).toThrow();
+  });
+
+  it('accepts valid agreedFurnitureIds', () => {
+    const result = inquiryFieldsSchema.parse({
+      agreedFurnitureIds: ['item-1', 'item-2'],
+    });
+    expect(result.agreedFurnitureIds).toEqual(['item-1', 'item-2']);
+  });
+
+  it('accepts valid viewingDate as ISO datetime', () => {
+    const result = inquiryFieldsSchema.parse({
+      viewingDate: '2026-03-01T10:00:00Z',
+    });
+    expect(result.viewingDate).toBe('2026-03-01T10:00:00Z');
+  });
+
+  it('rejects invalid viewingDate format', () => {
+    expect(() =>
+      inquiryFieldsSchema.parse({ viewingDate: '2026-03-01' })
+    ).toThrow();
+  });
+});

--- a/src/lib/validations/__tests__/message.test.ts
+++ b/src/lib/validations/__tests__/message.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest';
+import {
+  messageTypeSchema,
+  createMessageSchema,
+  createThreadSchema,
+} from '../message';
+
+describe('messageTypeSchema', () => {
+  it('accepts all valid types', () => {
+    const types = ['text', 'template', 'system'];
+    for (const t of types) {
+      expect(messageTypeSchema.parse(t)).toBe(t);
+    }
+  });
+
+  it('rejects invalid type', () => {
+    expect(() => messageTypeSchema.parse('image')).toThrow();
+  });
+});
+
+describe('createMessageSchema', () => {
+  const validMessage = {
+    threadId: 'thread-1',
+    body: 'こんにちは',
+  };
+
+  it('accepts valid message with defaults', () => {
+    const result = createMessageSchema.parse(validMessage);
+    expect(result.threadId).toBe('thread-1');
+    expect(result.body).toBe('こんにちは');
+    expect(result.messageType).toBe('text');
+  });
+
+  it('accepts message with explicit type', () => {
+    const result = createMessageSchema.parse({
+      ...validMessage,
+      messageType: 'template',
+    });
+    expect(result.messageType).toBe('template');
+  });
+
+  it('accepts message with metadata', () => {
+    const result = createMessageSchema.parse({
+      ...validMessage,
+      metadata: { templateId: 'greeting-1' },
+    });
+    expect(result.metadata).toEqual({ templateId: 'greeting-1' });
+  });
+
+  it('rejects empty body', () => {
+    expect(() =>
+      createMessageSchema.parse({ threadId: 'thread-1', body: '' })
+    ).toThrow();
+  });
+
+  it('rejects body exceeding 2000 characters', () => {
+    const longBody = 'あ'.repeat(2001);
+    expect(() =>
+      createMessageSchema.parse({ threadId: 'thread-1', body: longBody })
+    ).toThrow();
+  });
+
+  it('accepts body at exactly 2000 characters', () => {
+    const maxBody = 'a'.repeat(2000);
+    const result = createMessageSchema.parse({
+      threadId: 'thread-1',
+      body: maxBody,
+    });
+    expect(result.body.length).toBe(2000);
+  });
+
+  it('rejects empty threadId', () => {
+    expect(() =>
+      createMessageSchema.parse({ threadId: '', body: 'hello' })
+    ).toThrow();
+  });
+});
+
+describe('createThreadSchema', () => {
+  const validThread = {
+    propertyId: 'prop-1',
+    sellerId: 'seller-1',
+    buyerId: 'buyer-1',
+  };
+
+  it('accepts valid thread', () => {
+    expect(createThreadSchema.parse(validThread)).toEqual(validThread);
+  });
+
+  it('rejects missing propertyId', () => {
+    expect(() =>
+      createThreadSchema.parse({ sellerId: 'seller-1', buyerId: 'buyer-1' })
+    ).toThrow();
+  });
+
+  it('rejects empty sellerId', () => {
+    expect(() =>
+      createThreadSchema.parse({ ...validThread, sellerId: '' })
+    ).toThrow();
+  });
+
+  it('rejects empty buyerId', () => {
+    expect(() =>
+      createThreadSchema.parse({ ...validThread, buyerId: '' })
+    ).toThrow();
+  });
+});

--- a/src/lib/validations/__tests__/property.test.ts
+++ b/src/lib/validations/__tests__/property.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect } from 'vitest';
+import {
+  consentStatusSchema,
+  moveOutReasonSchema,
+  furnitureCategorySchema,
+  furnitureItemSchema,
+  landlordConsentSchema,
+  furniturePinSchema,
+} from '../property';
+
+describe('consentStatusSchema', () => {
+  it('accepts all valid statuses', () => {
+    const statuses = [
+      'pending',
+      'approved',
+      'conditional',
+      'rejected',
+      'expired',
+    ];
+    for (const status of statuses) {
+      expect(consentStatusSchema.parse(status)).toBe(status);
+    }
+  });
+
+  it('rejects invalid status', () => {
+    expect(() => consentStatusSchema.parse('unknown')).toThrow();
+  });
+});
+
+describe('moveOutReasonSchema', () => {
+  it('accepts all 8 valid reasons', () => {
+    const reasons = [
+      'job_transfer',
+      'job_change',
+      'marriage',
+      'family',
+      'upgrade',
+      'downsize',
+      'end_of_contract',
+      'other',
+    ];
+    for (const reason of reasons) {
+      expect(moveOutReasonSchema.parse(reason)).toBe(reason);
+    }
+  });
+
+  it('rejects invalid reason', () => {
+    expect(() => moveOutReasonSchema.parse('vacation')).toThrow();
+  });
+});
+
+describe('furnitureCategorySchema', () => {
+  it('accepts all 9 valid categories', () => {
+    const categories = [
+      'sofa',
+      'dining_table',
+      'bed_frame',
+      'desk',
+      'storage',
+      'chair',
+      'lighting',
+      'rug',
+      'other',
+    ];
+    for (const cat of categories) {
+      expect(furnitureCategorySchema.parse(cat)).toBe(cat);
+    }
+  });
+
+  it('rejects invalid category', () => {
+    expect(() => furnitureCategorySchema.parse('table')).toThrow();
+  });
+});
+
+describe('furniturePinSchema', () => {
+  it('accepts valid pin', () => {
+    const pin = { photoIndex: 0, x: 50.5, y: 25.0 };
+    expect(furniturePinSchema.parse(pin)).toEqual(pin);
+  });
+
+  it('rejects x > 100', () => {
+    expect(() =>
+      furniturePinSchema.parse({ photoIndex: 0, x: 101, y: 50 })
+    ).toThrow();
+  });
+
+  it('rejects negative y', () => {
+    expect(() =>
+      furniturePinSchema.parse({ photoIndex: 0, x: 50, y: -1 })
+    ).toThrow();
+  });
+});
+
+describe('furnitureItemSchema', () => {
+  const validItem = {
+    id: 'item-1',
+    name: 'ソファ',
+    category: 'core' as const,
+    furnitureCategory: 'sofa' as const,
+  };
+
+  it('accepts minimal valid item', () => {
+    expect(furnitureItemSchema.parse(validItem)).toEqual(validItem);
+  });
+
+  it('accepts item with all optional fields', () => {
+    const fullItem = {
+      ...validItem,
+      description: 'IKEA製の3人掛けソファ',
+      photoUrl: 'https://example.com/photo.jpg',
+      price: 30000,
+      brand: 'IKEA',
+      newPrice: 50000,
+      yearsUsed: 2,
+      pin: { photoIndex: 0, x: 30, y: 60 },
+    };
+    expect(furnitureItemSchema.parse(fullItem)).toEqual(fullItem);
+  });
+
+  it('rejects empty id', () => {
+    expect(() => furnitureItemSchema.parse({ ...validItem, id: '' })).toThrow();
+  });
+
+  it('rejects invalid category value', () => {
+    expect(() =>
+      furnitureItemSchema.parse({ ...validItem, category: 'premium' })
+    ).toThrow();
+  });
+
+  it('rejects invalid furnitureCategory', () => {
+    expect(() =>
+      furnitureItemSchema.parse({ ...validItem, furnitureCategory: 'couch' })
+    ).toThrow();
+  });
+
+  it('rejects negative price', () => {
+    expect(() =>
+      furnitureItemSchema.parse({ ...validItem, price: -100 })
+    ).toThrow();
+  });
+
+  it('rejects invalid photoUrl', () => {
+    expect(() =>
+      furnitureItemSchema.parse({ ...validItem, photoUrl: 'not-a-url' })
+    ).toThrow();
+  });
+});
+
+describe('landlordConsentSchema', () => {
+  it('accepts minimal consent (status only)', () => {
+    const consent = { status: 'pending' as const };
+    expect(landlordConsentSchema.parse(consent)).toEqual(consent);
+  });
+
+  it('accepts full consent with all fields', () => {
+    const consent = {
+      status: 'conditional' as const,
+      approvedItems: ['sofa', 'desk'],
+      rejectedItems: ['lighting'],
+      conditions: '退去時に清掃必要',
+      restorationTerms: '原状回復不要',
+      approvedAt: '2026-01-15T10:00:00Z',
+      approvedBy: '山田太郎',
+    };
+    expect(landlordConsentSchema.parse(consent)).toEqual(consent);
+  });
+
+  it('rejects missing status', () => {
+    expect(() => landlordConsentSchema.parse({})).toThrow();
+  });
+
+  it('rejects invalid status', () => {
+    expect(() => landlordConsentSchema.parse({ status: 'maybe' })).toThrow();
+  });
+});

--- a/src/lib/validations/index.ts
+++ b/src/lib/validations/index.ts
@@ -1,0 +1,29 @@
+export {
+  consentStatusSchema,
+  moveOutReasonSchema,
+  furnitureCategorySchema,
+  furniturePinSchema,
+  furnitureItemSchema,
+  landlordConsentSchema,
+} from './property';
+export type {
+  ConsentStatusInput,
+  MoveOutReasonInput,
+  FurnitureCategoryInput,
+  FurnitureItemInput,
+  LandlordConsentInput,
+} from './property';
+
+export { inquiryFieldsSchema } from './inquiry';
+export type { InquiryFieldsInput } from './inquiry';
+
+export {
+  messageTypeSchema,
+  createMessageSchema,
+  createThreadSchema,
+} from './message';
+export type {
+  MessageTypeInput,
+  CreateMessageInput,
+  CreateThreadInput,
+} from './message';

--- a/src/lib/validations/inquiry.ts
+++ b/src/lib/validations/inquiry.ts
@@ -1,0 +1,11 @@
+import zod from 'zod';
+const z = zod;
+
+// Inquiry-specific validation fields (§7.2)
+export const inquiryFieldsSchema = z.object({
+  duration: z.string().max(100).optional(),
+  agreedFurnitureIds: z.array(z.string()).optional(),
+  viewingDate: z.string().datetime().optional(),
+});
+
+export type InquiryFieldsInput = zod.infer<typeof inquiryFieldsSchema>;

--- a/src/lib/validations/message.ts
+++ b/src/lib/validations/message.ts
@@ -1,0 +1,24 @@
+import zod from 'zod';
+const z = zod;
+
+// MessageType enum (§7.9)
+export const messageTypeSchema = z.enum(['text', 'template', 'system']);
+
+// Create message schema (§7.9)
+export const createMessageSchema = z.object({
+  threadId: z.string().min(1),
+  body: z.string().min(1).max(2000),
+  messageType: messageTypeSchema.default('text'),
+  metadata: z.record(z.unknown()).optional(),
+});
+
+// Create thread schema (§7.8)
+export const createThreadSchema = z.object({
+  propertyId: z.string().min(1),
+  sellerId: z.string().min(1),
+  buyerId: z.string().min(1),
+});
+
+export type MessageTypeInput = zod.infer<typeof messageTypeSchema>;
+export type CreateMessageInput = zod.infer<typeof createMessageSchema>;
+export type CreateThreadInput = zod.infer<typeof createThreadSchema>;

--- a/src/lib/validations/property.ts
+++ b/src/lib/validations/property.ts
@@ -1,0 +1,76 @@
+import zod from 'zod';
+const z = zod;
+
+// ConsentStatus enum (§7.4)
+export const consentStatusSchema = z.enum([
+  'pending',
+  'approved',
+  'conditional',
+  'rejected',
+  'expired',
+]);
+
+// MoveOutReason enum (§7.6)
+export const moveOutReasonSchema = z.enum([
+  'job_transfer',
+  'job_change',
+  'marriage',
+  'family',
+  'upgrade',
+  'downsize',
+  'end_of_contract',
+  'other',
+]);
+
+// FurnitureCategory enum (§7.7.1)
+export const furnitureCategorySchema = z.enum([
+  'sofa',
+  'dining_table',
+  'bed_frame',
+  'desk',
+  'storage',
+  'chair',
+  'lighting',
+  'rug',
+  'other',
+]);
+
+// FurnitureItem pin location on room photo
+export const furniturePinSchema = z.object({
+  photoIndex: z.number().int().nonnegative(),
+  x: z.number().min(0).max(100),
+  y: z.number().min(0).max(100),
+});
+
+// FurnitureItem structure (§7.7)
+export const furnitureItemSchema = z.object({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  category: z.enum(['core', 'additional']),
+  furnitureCategory: furnitureCategorySchema,
+  description: z.string().optional(),
+  photoUrl: z.string().url().optional(),
+  price: z.number().int().nonnegative().optional(),
+  brand: z.string().optional(),
+  newPrice: z.number().int().nonnegative().optional(),
+  yearsUsed: z.number().nonnegative().optional(),
+  pin: furniturePinSchema.optional(),
+});
+
+// LandlordConsent structure (§7.4)
+export const landlordConsentSchema = z.object({
+  status: consentStatusSchema,
+  approvedItems: z.array(z.string()).optional(),
+  rejectedItems: z.array(z.string()).optional(),
+  conditions: z.string().optional(),
+  restorationTerms: z.string().optional(),
+  approvedAt: z.string().optional(),
+  approvedBy: z.string().optional(),
+});
+
+// Inferred types (for use outside DB schema context)
+export type ConsentStatusInput = zod.infer<typeof consentStatusSchema>;
+export type MoveOutReasonInput = zod.infer<typeof moveOutReasonSchema>;
+export type FurnitureCategoryInput = zod.infer<typeof furnitureCategorySchema>;
+export type FurnitureItemInput = zod.infer<typeof furnitureItemSchema>;
+export type LandlordConsentInput = zod.infer<typeof landlordConsentSchema>;


### PR DESCRIPTION
## Summary
- New `src/lib/validations/` directory with shared Zod schemas for Phase 0 data models
- Property schemas: ConsentStatus (5 values), MoveOutReason (8 values), FurnitureCategory (9 values), FurnitureItem (with pin), LandlordConsent
- Inquiry schema: duration, agreedFurnitureIds, viewingDate
- Message schemas: messageType enum, createMessage (body max 2000 chars), createThread
- 39 unit tests covering all enum values, boundary conditions, and validation rules
- Updated API routes to use shared `furnitureItemSchema` instead of `z.any()`
- Updated API routes to use shared `landlordConsentSchema` instead of inline definition

## Test plan
- [x] All 39 unit tests pass (`bun run test:run -- src/lib/validations`)
- [x] TypeScript compiles clean (`bunx tsc --noEmit`)
- [ ] CI lint, types, unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)