### PR TITLE
feat: add consultation document PDF template (F-611)

### DIFF
--- a/src/lib/pdf/__tests__/consultation-document.test.tsx
+++ b/src/lib/pdf/__tests__/consultation-document.test.tsx
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createElement } from 'react';
+
+vi.mock('@react-pdf/renderer', () => ({
+  Document: ({ children }: { children: React.ReactNode }) =>
+    createElement('document', null, children),
+  Page: ({ children, size }: { children: React.ReactNode; size: string }) =>
+    createElement('page', { 'data-size': size }, children),
+  Text: ({ children }: { children: React.ReactNode }) =>
+    createElement('text', null, children),
+  View: ({ children }: { children: React.ReactNode }) =>
+    createElement('view', null, children),
+  Link: ({ children, src }: { children: React.ReactNode; src: string }) =>
+    createElement('a', { href: src }, children),
+  StyleSheet: {
+    create: <T extends Record<string, unknown>>(styles: T) => styles,
+  },
+}));
+
+const { ConsultationDocument } =
+  await import('../templates/consultation-document');
+
+describe('ConsultationDocument', () => {
+  const defaultProps = {
+    propertyName: '渋谷区神宮前 1LDK',
+    propertyAddress: '東京都渋谷区神宮前1-2-3',
+    moveOutDate: '2026年3月31日',
+    sellerName: '山田太郎',
+    furnitureItems: [
+      { name: 'ソファ', category: 'コア', description: '3人掛け、良好' },
+      { name: 'ダイニングテーブル', category: 'コア' },
+      { name: 'デスクランプ', category: '追加', description: 'IKEA製' },
+    ],
+    createdDate: '2026年2月7日',
+  };
+
+  it('renders without error', () => {
+    const element = ConsultationDocument(defaultProps);
+    expect(element).toBeTruthy();
+  });
+
+  it('includes property name', () => {
+    const element = ConsultationDocument(defaultProps);
+    const json = JSON.stringify(element);
+    expect(json).toContain('渋谷区神宮前 1LDK');
+  });
+
+  it('includes property address', () => {
+    const element = ConsultationDocument(defaultProps);
+    const json = JSON.stringify(element);
+    expect(json).toContain('東京都渋谷区神宮前1-2-3');
+  });
+
+  it('includes move-out date', () => {
+    const element = ConsultationDocument(defaultProps);
+    const json = JSON.stringify(element);
+    expect(json).toContain('2026年3月31日');
+  });
+
+  it('includes seller name', () => {
+    const element = ConsultationDocument(defaultProps);
+    const json = JSON.stringify(element);
+    expect(json).toContain('山田太郎');
+  });
+
+  it('includes all furniture items', () => {
+    const element = ConsultationDocument(defaultProps);
+    const json = JSON.stringify(element);
+    expect(json).toContain('ソファ');
+    expect(json).toContain('ダイニングテーブル');
+    expect(json).toContain('デスクランプ');
+  });
+
+  it('includes furniture count in section title', () => {
+    const element = ConsultationDocument(defaultProps);
+    const json = JSON.stringify(element);
+    expect(json).toContain('暫定家具リスト');
+    // Count is rendered as separate children: ["暫定家具リスト（", 3, "点）"]
+    expect(json).toContain('"children":["暫定家具リスト（",3,"点）"]');
+  });
+
+  it('includes tsumugi branding', () => {
+    const element = ConsultationDocument(defaultProps);
+    const json = JSON.stringify(element);
+    expect(json).toContain('tsumugi');
+  });
+
+  it('includes tsumugi explanation section', () => {
+    const element = ConsultationDocument(defaultProps);
+    const json = JSON.stringify(element);
+    expect(json).toContain('tsumugiとは');
+    expect(json).toContain('引き継ぎ');
+  });
+
+  it('includes action steps for management company', () => {
+    const element = ConsultationDocument(defaultProps);
+    const json = JSON.stringify(element);
+    expect(json).toContain('内容のご確認');
+    expect(json).toContain('オーナー様への転送');
+    expect(json).toContain('承認結果のご連絡');
+  });
+
+  it('uses A4 page size', () => {
+    const element = ConsultationDocument(defaultProps);
+    const json = JSON.stringify(element);
+    expect(json).toContain('A4');
+  });
+
+  it('shows dash for items without description', () => {
+    const element = ConsultationDocument(defaultProps);
+    const json = JSON.stringify(element);
+    expect(json).toContain('—');
+  });
+
+  it('includes creation date', () => {
+    const element = ConsultationDocument(defaultProps);
+    const json = JSON.stringify(element);
+    expect(json).toContain('2026年2月7日');
+  });
+});

--- a/src/lib/pdf/index.ts
+++ b/src/lib/pdf/index.ts
@@ -1,3 +1,4 @@
 export { registerFonts } from './fonts';
 export { renderPdf } from './render';
 export { SampleDocument } from './templates/sample';
+export { ConsultationDocument } from './templates/consultation-document';

--- a/src/lib/pdf/templates/consultation-document.tsx
+++ b/src/lib/pdf/templates/consultation-document.tsx
@@ -1,0 +1,313 @@
+import {
+  Document,
+  Page,
+  Text,
+  View,
+  StyleSheet,
+  Link,
+} from '@react-pdf/renderer';
+
+const styles = StyleSheet.create({
+  page: {
+    fontFamily: 'Noto Sans JP',
+    fontSize: 10,
+    padding: '36 44',
+    color: '#333333',
+    lineHeight: 1.6,
+  },
+  header: {
+    marginBottom: 20,
+    borderBottom: '2 solid #FF5A5F',
+    paddingBottom: 12,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'flex-end',
+  },
+  logo: {
+    fontSize: 20,
+    fontWeight: 700,
+    color: '#FF5A5F',
+    letterSpacing: -0.5,
+  },
+  headerDate: {
+    fontSize: 9,
+    color: '#666666',
+  },
+  title: {
+    fontSize: 16,
+    fontWeight: 700,
+    marginBottom: 20,
+    textAlign: 'center',
+    color: '#333333',
+  },
+  section: {
+    marginBottom: 16,
+  },
+  sectionTitle: {
+    fontSize: 12,
+    fontWeight: 700,
+    color: '#FF5A5F',
+    marginBottom: 8,
+    borderBottom: '1 solid #eeeeee',
+    paddingBottom: 4,
+  },
+  row: {
+    flexDirection: 'row',
+    marginBottom: 4,
+    paddingVertical: 2,
+  },
+  label: {
+    width: 120,
+    fontSize: 9,
+    color: '#666666',
+    fontWeight: 700,
+  },
+  value: {
+    flex: 1,
+    fontSize: 10,
+  },
+  tableHeader: {
+    flexDirection: 'row',
+    backgroundColor: '#f5f5f5',
+    borderBottom: '1 solid #dddddd',
+    paddingVertical: 6,
+    paddingHorizontal: 8,
+  },
+  tableRow: {
+    flexDirection: 'row',
+    borderBottom: '1 solid #eeeeee',
+    paddingVertical: 5,
+    paddingHorizontal: 8,
+  },
+  tableColName: {
+    width: '40%',
+    fontSize: 9,
+  },
+  tableColCategory: {
+    width: '20%',
+    fontSize: 9,
+  },
+  tableColDesc: {
+    width: '40%',
+    fontSize: 9,
+    color: '#666666',
+  },
+  tableHeaderText: {
+    fontSize: 8,
+    fontWeight: 700,
+    color: '#666666',
+    textTransform: 'uppercase',
+  },
+  stepBox: {
+    flexDirection: 'row',
+    marginBottom: 8,
+    alignItems: 'flex-start',
+  },
+  stepNumber: {
+    width: 22,
+    height: 22,
+    borderRadius: 11,
+    backgroundColor: '#FF5A5F',
+    color: '#ffffff',
+    fontSize: 10,
+    fontWeight: 700,
+    textAlign: 'center',
+    lineHeight: 22,
+    marginRight: 10,
+    paddingTop: 4,
+  },
+  stepContent: {
+    flex: 1,
+  },
+  stepTitle: {
+    fontSize: 10,
+    fontWeight: 700,
+    marginBottom: 2,
+  },
+  stepDesc: {
+    fontSize: 9,
+    color: '#555555',
+  },
+  infoBox: {
+    backgroundColor: '#FFF5F5',
+    borderLeft: '3 solid #FF5A5F',
+    padding: '10 14',
+    marginBottom: 12,
+  },
+  infoText: {
+    fontSize: 9,
+    color: '#555555',
+    lineHeight: 1.5,
+  },
+  footer: {
+    position: 'absolute',
+    bottom: 30,
+    left: 44,
+    right: 44,
+    borderTop: '1 solid #eeeeee',
+    paddingTop: 8,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
+  footerText: {
+    fontSize: 7,
+    color: '#999999',
+  },
+  footerLink: {
+    fontSize: 7,
+    color: '#FF5A5F',
+    textDecoration: 'none',
+  },
+});
+
+interface FurnitureItem {
+  name: string;
+  category: string;
+  description?: string;
+}
+
+interface ConsultationDocumentProps {
+  propertyName: string;
+  propertyAddress: string;
+  moveOutDate: string;
+  sellerName: string;
+  furnitureItems: FurnitureItem[];
+  createdDate: string;
+}
+
+export function ConsultationDocument({
+  propertyName,
+  propertyAddress,
+  moveOutDate,
+  sellerName,
+  furnitureItems,
+  createdDate,
+}: ConsultationDocumentProps) {
+  const actionSteps = [
+    {
+      title: '内容のご確認',
+      desc: '本資料に記載の家具リストと引き継ぎの仕組みをご確認ください。',
+    },
+    {
+      title: 'オーナー様への転送',
+      desc: '必要に応じて物件オーナー（大家）様へ本資料を転送してください。',
+    },
+    {
+      title: '承認結果のご連絡',
+      desc: '承認・条件付き承認・不承認のいずれかを前の住人へお伝えください。',
+    },
+  ];
+
+  return (
+    <Document>
+      <Page size="A4" style={styles.page}>
+        {/* Header */}
+        <View style={styles.header}>
+          <Text style={styles.logo}>tsumugi</Text>
+          <Text style={styles.headerDate}>作成日: {createdDate}</Text>
+        </View>
+
+        {/* Title */}
+        <Text style={styles.title}>残置物引き継ぎのご相談</Text>
+
+        {/* Property Info */}
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>物件情報</Text>
+          <View style={styles.row}>
+            <Text style={styles.label}>物件名</Text>
+            <Text style={styles.value}>{propertyName}</Text>
+          </View>
+          <View style={styles.row}>
+            <Text style={styles.label}>所在地</Text>
+            <Text style={styles.value}>{propertyAddress}</Text>
+          </View>
+          <View style={styles.row}>
+            <Text style={styles.label}>退去予定日</Text>
+            <Text style={styles.value}>{moveOutDate}</Text>
+          </View>
+          <View style={styles.row}>
+            <Text style={styles.label}>前の住人</Text>
+            <Text style={styles.value}>{sellerName}</Text>
+          </View>
+        </View>
+
+        {/* What is tsumugi */}
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>tsumugiとは</Text>
+          <View style={styles.infoBox}>
+            <Text style={styles.infoText}>
+              tsumugiは、前の住人が大切に使ってきた家具・インテリアを次の住人へ引き継ぐためのサービスです。
+              処分ではなく「引き継ぎ」という形で、環境に配慮しながら前の住人の負担を軽減します。
+              次の住人候補は、tsumugiのプラットフォームを通じてマッチングされ、
+              内見後に引き継ぎの合意が成立します。
+            </Text>
+          </View>
+        </View>
+
+        {/* Furniture List */}
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>
+            暫定家具リスト（{furnitureItems.length}点）
+          </Text>
+          <View style={styles.tableHeader}>
+            <Text style={[styles.tableColName, styles.tableHeaderText]}>
+              品名
+            </Text>
+            <Text style={[styles.tableColCategory, styles.tableHeaderText]}>
+              カテゴリ
+            </Text>
+            <Text style={[styles.tableColDesc, styles.tableHeaderText]}>
+              備考
+            </Text>
+          </View>
+          {furnitureItems.map((item, index) => (
+            <View key={index} style={styles.tableRow}>
+              <Text style={styles.tableColName}>{item.name}</Text>
+              <Text style={styles.tableColCategory}>{item.category}</Text>
+              <Text style={styles.tableColDesc}>{item.description ?? '—'}</Text>
+            </View>
+          ))}
+        </View>
+
+        {/* Action Steps */}
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>管理会社様へのお願い</Text>
+          {actionSteps.map((step, index) => (
+            <View key={index} style={styles.stepBox}>
+              <Text style={styles.stepNumber}>{index + 1}</Text>
+              <View style={styles.stepContent}>
+                <Text style={styles.stepTitle}>{step.title}</Text>
+                <Text style={styles.stepDesc}>{step.desc}</Text>
+              </View>
+            </View>
+          ))}
+        </View>
+
+        {/* Notes */}
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>備考</Text>
+          <Text style={styles.infoText}>
+            ・次の住人候補への内見が実施される場合があります。内見日程は事前にご連絡いたします。
+          </Text>
+          <Text style={styles.infoText}>
+            ・家具リストは暫定であり、最終的な引き継ぎ品目は合意時に確定します。
+          </Text>
+          <Text style={styles.infoText}>
+            ・ご不明な点がございましたら、info@tsumugi.com
+            までお問い合わせください。
+          </Text>
+        </View>
+
+        {/* Footer */}
+        <View style={styles.footer} fixed>
+          <Text style={styles.footerText}>
+            © {new Date().getFullYear()} tsumugi. All rights reserved.
+          </Text>
+          <Link src="https://tsumugi.com" style={styles.footerLink}>
+            https://tsumugi.com
+          </Link>
+        </View>
+      </Page>
+    </Document>
+  );
+}


### PR DESCRIPTION
## Summary
- Create 残置物引き継ぎ相談資料 (furniture handover consultation document) PDF template
- Self-contained document for management companies to understand tsumugi's furniture handover process
- Uses @react-pdf/renderer with Noto Sans JP fonts (set up in PR #227)
- 13 unit tests covering all template sections

## Contents
- **Property info section** - name, address, move-out date, seller
- **tsumugi explanation** - what the service is and how it works
- **Furniture list table** - items with categories and descriptions
- **3-step action guide** - confirm contents, forward to owner, report approval result
- **Notes section** - viewing logistics, preliminary nature of list, contact info
- **tsumugi branding** - coral accent, footer with URL

## Changes
- `src/lib/pdf/templates/consultation-document.tsx` - New PDF template
- `src/lib/pdf/__tests__/consultation-document.test.tsx` - 13 tests
- `src/lib/pdf/index.ts` - Added ConsultationDocument export

## Test plan
- [x] All 13 tests pass
- [x] TypeScript compiles cleanly
- [x] Template includes all required sections per F-611 spec
- [x] Uses A4 page size, tsumugi branding

🤖 Generated with [Claude Code](https://claude.com/claude-code)