### PR TITLE
feat: add consent form PDF template (F-612)

### DIFF
--- a/src/lib/pdf/__tests__/consent-form.test.tsx
+++ b/src/lib/pdf/__tests__/consent-form.test.tsx
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createElement } from 'react';
+
+vi.mock('@react-pdf/renderer', () => ({
+  Document: ({ children }: { children: React.ReactNode }) =>
+    createElement('document', null, children),
+  Page: ({ children, size }: { children: React.ReactNode; size: string }) =>
+    createElement('page', { 'data-size': size }, children),
+  Text: ({ children }: { children: React.ReactNode }) =>
+    createElement('text', null, children),
+  View: ({ children }: { children: React.ReactNode }) =>
+    createElement('view', null, children),
+  StyleSheet: {
+    create: <T extends Record<string, unknown>>(styles: T) => styles,
+  },
+}));
+
+const { ConsentForm } = await import('../templates/consent-form');
+
+describe('ConsentForm', () => {
+  const defaultProps = {
+    propertyAddress: '東京都渋谷区神宮前1-2-3',
+    roomNumber: '301',
+    sellerName: '山田太郎',
+    buyerName: '佐藤花子',
+    furnitureItems: [
+      {
+        name: 'ソファ',
+        category: 'リビング',
+        condition: '良好',
+        remarks: '3人掛け',
+      },
+      { name: 'ダイニングテーブル', category: 'ダイニング', condition: '普通' },
+      { name: 'デスクランプ', category: '書斎' },
+    ],
+    createdDate: '2026年2月7日',
+  };
+
+  it('renders without error', () => {
+    const element = ConsentForm(defaultProps);
+    expect(element).toBeTruthy();
+  });
+
+  it('includes property address', () => {
+    const element = ConsentForm(defaultProps);
+    const json = JSON.stringify(element);
+    expect(json).toContain('東京都渋谷区神宮前1-2-3');
+  });
+
+  it('includes room number', () => {
+    const element = ConsentForm(defaultProps);
+    const json = JSON.stringify(element);
+    expect(json).toContain('301');
+  });
+
+  it('includes seller name', () => {
+    const element = ConsentForm(defaultProps);
+    const json = JSON.stringify(element);
+    expect(json).toContain('山田太郎');
+  });
+
+  it('includes buyer name', () => {
+    const element = ConsentForm(defaultProps);
+    const json = JSON.stringify(element);
+    expect(json).toContain('佐藤花子');
+  });
+
+  it('includes all furniture items', () => {
+    const element = ConsentForm(defaultProps);
+    const json = JSON.stringify(element);
+    expect(json).toContain('ソファ');
+    expect(json).toContain('ダイニングテーブル');
+    expect(json).toContain('デスクランプ');
+  });
+
+  it('includes furniture count in section title', () => {
+    const element = ConsentForm(defaultProps);
+    const json = JSON.stringify(element);
+    expect(json).toContain('引き継ぎ対象物品');
+    // Count rendered as separate children: ["3. 引き継ぎ対象物品（", 3, "点）"]
+    expect(json).toContain('"children":["3. 引き継ぎ対象物品（",3,"点）"]');
+  });
+
+  it('includes terms and clauses', () => {
+    const element = ConsentForm(defaultProps);
+    const json = JSON.stringify(element);
+    expect(json).toContain('合意事項・責任分界');
+    expect(json).toContain('現状有姿');
+    expect(json).toContain('瑕疵');
+  });
+
+  it('includes signature section', () => {
+    const element = ConsentForm(defaultProps);
+    const json = JSON.stringify(element);
+    expect(json).toContain('署名');
+    expect(json).toContain('前の住人（甲）');
+    expect(json).toContain('次の住人（乙）');
+    expect(json).toContain('承認（管理会社）');
+  });
+
+  it('shows dash for missing condition', () => {
+    const element = ConsentForm(defaultProps);
+    const json = JSON.stringify(element);
+    expect(json).toContain('—');
+  });
+
+  it('uses A4 page size', () => {
+    const element = ConsentForm(defaultProps);
+    const json = JSON.stringify(element);
+    expect(json).toContain('A4');
+  });
+
+  it('includes tsumugi branding', () => {
+    const element = ConsentForm(defaultProps);
+    const json = JSON.stringify(element);
+    expect(json).toContain('tsumugi');
+  });
+
+  it('includes creation date', () => {
+    const element = ConsentForm(defaultProps);
+    const json = JSON.stringify(element);
+    expect(json).toContain('2026年2月7日');
+  });
+
+  it('renders blank line when buyer name is not provided', () => {
+    const propsWithoutBuyer = { ...defaultProps, buyerName: undefined };
+    const element = ConsentForm(propsWithoutBuyer);
+    expect(element).toBeTruthy();
+    const json = JSON.stringify(element);
+    expect(json).not.toContain('佐藤花子');
+  });
+});

--- a/src/lib/pdf/index.ts
+++ b/src/lib/pdf/index.ts
@@ -2,3 +2,4 @@ export { registerFonts } from './fonts';
 export { renderPdf } from './render';
 export { SampleDocument } from './templates/sample';
 export { ConsultationDocument } from './templates/consultation-document';
+export { ConsentForm } from './templates/consent-form';

--- a/src/lib/pdf/templates/consent-form.tsx
+++ b/src/lib/pdf/templates/consent-form.tsx
@@ -1,0 +1,325 @@
+import { Document, Page, Text, View, StyleSheet } from '@react-pdf/renderer';
+
+const styles = StyleSheet.create({
+  page: {
+    fontFamily: 'Noto Sans JP',
+    fontSize: 10,
+    padding: '36 44',
+    color: '#333333',
+    lineHeight: 1.5,
+  },
+  header: {
+    marginBottom: 16,
+    borderBottom: '2 solid #333333',
+    paddingBottom: 8,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'flex-end',
+  },
+  logo: {
+    fontSize: 14,
+    fontWeight: 700,
+    color: '#FF5A5F',
+  },
+  docId: {
+    fontSize: 8,
+    color: '#999999',
+  },
+  title: {
+    fontSize: 16,
+    fontWeight: 700,
+    textAlign: 'center',
+    marginBottom: 20,
+  },
+  section: {
+    marginBottom: 14,
+  },
+  sectionTitle: {
+    fontSize: 11,
+    fontWeight: 700,
+    marginBottom: 6,
+    backgroundColor: '#f5f5f5',
+    padding: '4 8',
+  },
+  row: {
+    flexDirection: 'row',
+    borderBottom: '1 solid #eeeeee',
+    paddingVertical: 4,
+    paddingHorizontal: 8,
+  },
+  label: {
+    width: 110,
+    fontSize: 9,
+    color: '#666666',
+    fontWeight: 700,
+  },
+  value: {
+    flex: 1,
+    fontSize: 10,
+  },
+  blankLine: {
+    flex: 1,
+    fontSize: 10,
+    borderBottom: '1 dotted #cccccc',
+    minHeight: 16,
+  },
+  tableHeader: {
+    flexDirection: 'row',
+    backgroundColor: '#f5f5f5',
+    borderBottom: '1 solid #cccccc',
+    paddingVertical: 5,
+    paddingHorizontal: 8,
+  },
+  tableRow: {
+    flexDirection: 'row',
+    borderBottom: '1 solid #eeeeee',
+    paddingVertical: 5,
+    paddingHorizontal: 8,
+    minHeight: 20,
+  },
+  tableColNo: {
+    width: '8%',
+    fontSize: 9,
+  },
+  tableColName: {
+    width: '30%',
+    fontSize: 9,
+  },
+  tableColCategory: {
+    width: '18%',
+    fontSize: 9,
+  },
+  tableColCondition: {
+    width: '20%',
+    fontSize: 9,
+  },
+  tableColRemarks: {
+    width: '24%',
+    fontSize: 9,
+  },
+  tableHeaderText: {
+    fontSize: 8,
+    fontWeight: 700,
+    color: '#666666',
+  },
+  clause: {
+    fontSize: 9,
+    marginBottom: 6,
+    paddingLeft: 8,
+    lineHeight: 1.6,
+  },
+  signatureBlock: {
+    marginTop: 12,
+    borderTop: '1 solid #eeeeee',
+    paddingTop: 12,
+  },
+  signatureRow: {
+    flexDirection: 'row',
+    marginBottom: 16,
+    alignItems: 'flex-end',
+  },
+  signatureLabel: {
+    width: 100,
+    fontSize: 9,
+    fontWeight: 700,
+    color: '#666666',
+  },
+  signatureLine: {
+    flex: 1,
+    borderBottom: '1 solid #333333',
+    minHeight: 20,
+    marginRight: 16,
+  },
+  signatureDate: {
+    width: 140,
+    fontSize: 9,
+    color: '#666666',
+  },
+  dateLine: {
+    borderBottom: '1 dotted #cccccc',
+    minHeight: 16,
+    width: 100,
+  },
+  footer: {
+    position: 'absolute',
+    bottom: 28,
+    left: 44,
+    right: 44,
+    borderTop: '1 solid #eeeeee',
+    paddingTop: 6,
+    fontSize: 7,
+    color: '#999999',
+    textAlign: 'center',
+  },
+});
+
+interface FurnitureItem {
+  name: string;
+  category: string;
+  condition?: string;
+  remarks?: string;
+}
+
+interface ConsentFormProps {
+  propertyAddress: string;
+  roomNumber?: string;
+  sellerName: string;
+  buyerName?: string;
+  furnitureItems: FurnitureItem[];
+  createdDate: string;
+}
+
+export function ConsentForm({
+  propertyAddress,
+  roomNumber,
+  sellerName,
+  buyerName,
+  furnitureItems,
+  createdDate,
+}: ConsentFormProps) {
+  return (
+    <Document>
+      <Page size="A4" style={styles.page}>
+        {/* Header */}
+        <View style={styles.header}>
+          <Text style={styles.logo}>tsumugi</Text>
+          <Text style={styles.docId}>作成日: {createdDate}</Text>
+        </View>
+
+        {/* Title */}
+        <Text style={styles.title}>残置物引き継ぎ同意書</Text>
+
+        {/* Property Info */}
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>1. 物件情報</Text>
+          <View style={styles.row}>
+            <Text style={styles.label}>物件所在地</Text>
+            <Text style={styles.value}>{propertyAddress}</Text>
+          </View>
+          <View style={styles.row}>
+            <Text style={styles.label}>部屋番号</Text>
+            {roomNumber ? (
+              <Text style={styles.value}>{roomNumber}</Text>
+            ) : (
+              <View style={styles.blankLine} />
+            )}
+          </View>
+        </View>
+
+        {/* Parties */}
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>2. 当事者</Text>
+          <View style={styles.row}>
+            <Text style={styles.label}>前の住人（甲）</Text>
+            {sellerName ? (
+              <Text style={styles.value}>{sellerName}</Text>
+            ) : (
+              <View style={styles.blankLine} />
+            )}
+          </View>
+          <View style={styles.row}>
+            <Text style={styles.label}>次の住人（乙）</Text>
+            {buyerName ? (
+              <Text style={styles.value}>{buyerName}</Text>
+            ) : (
+              <View style={styles.blankLine} />
+            )}
+          </View>
+        </View>
+
+        {/* Furniture List */}
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>
+            3. 引き継ぎ対象物品（{furnitureItems.length}点）
+          </Text>
+          <View style={styles.tableHeader}>
+            <Text style={[styles.tableColNo, styles.tableHeaderText]}>No.</Text>
+            <Text style={[styles.tableColName, styles.tableHeaderText]}>
+              品名
+            </Text>
+            <Text style={[styles.tableColCategory, styles.tableHeaderText]}>
+              カテゴリ
+            </Text>
+            <Text style={[styles.tableColCondition, styles.tableHeaderText]}>
+              状態
+            </Text>
+            <Text style={[styles.tableColRemarks, styles.tableHeaderText]}>
+              備考
+            </Text>
+          </View>
+          {furnitureItems.map((item, index) => (
+            <View key={index} style={styles.tableRow}>
+              <Text style={styles.tableColNo}>{index + 1}</Text>
+              <Text style={styles.tableColName}>{item.name}</Text>
+              <Text style={styles.tableColCategory}>{item.category}</Text>
+              <Text style={styles.tableColCondition}>
+                {item.condition ?? '—'}
+              </Text>
+              <Text style={styles.tableColRemarks}>{item.remarks ?? '—'}</Text>
+            </View>
+          ))}
+        </View>
+
+        {/* Terms */}
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>4. 合意事項・責任分界</Text>
+          <Text style={styles.clause}>
+            (1)
+            甲は上記物品を現状有姿にて乙に引き渡すものとし、引き渡し後の物品に関する責任は乙に移転するものとします。
+          </Text>
+          <Text style={styles.clause}>
+            (2)
+            乙は引き渡し前に物品の状態を確認し、確認済みの上で引き受けるものとします。
+          </Text>
+          <Text style={styles.clause}>
+            (3)
+            引き渡し後に発見された物品の瑕疵について、甲は一切の責任を負わないものとします。
+          </Text>
+          <Text style={styles.clause}>
+            (4)
+            本同意書の内容は、物件オーナーまたは管理会社の承認を得た上で効力を有するものとします。
+          </Text>
+        </View>
+
+        {/* Signatures */}
+        <View style={styles.signatureBlock}>
+          <Text style={styles.sectionTitle}>5. 署名</Text>
+
+          <View style={styles.signatureRow}>
+            <Text style={styles.signatureLabel}>前の住人（甲）</Text>
+            <View style={styles.signatureLine} />
+            <View style={{ flexDirection: 'row', alignItems: 'flex-end' }}>
+              <Text style={styles.signatureDate}>日付: </Text>
+              <View style={styles.dateLine} />
+            </View>
+          </View>
+
+          <View style={styles.signatureRow}>
+            <Text style={styles.signatureLabel}>次の住人（乙）</Text>
+            <View style={styles.signatureLine} />
+            <View style={{ flexDirection: 'row', alignItems: 'flex-end' }}>
+              <Text style={styles.signatureDate}>日付: </Text>
+              <View style={styles.dateLine} />
+            </View>
+          </View>
+
+          <View style={styles.signatureRow}>
+            <Text style={styles.signatureLabel}>承認（管理会社）</Text>
+            <View style={styles.signatureLine} />
+            <View style={{ flexDirection: 'row', alignItems: 'flex-end' }}>
+              <Text style={styles.signatureDate}>日付: </Text>
+              <View style={styles.dateLine} />
+            </View>
+          </View>
+        </View>
+
+        {/* Footer */}
+        <View style={styles.footer} fixed>
+          <Text>
+            tsumugi 残置物引き継ぎ同意書 | © {new Date().getFullYear()} tsumugi
+          </Text>
+        </View>
+      </Page>
+    </Document>
+  );
+}


### PR DESCRIPTION
## Summary
- Add `ConsentForm` PDF template for 残置物引き継ぎ同意書 (furniture handover consent form)
- Template includes: property info, parties (seller/buyer), furniture list table, terms/clauses (4 liability clauses), and signature block for 3 parties (seller, buyer, management company)
- Export from `@/lib/pdf` barrel file
- 14 unit tests covering all sections, edge cases (missing buyer name, missing condition/remarks)

## Test plan
- [x] 14 unit tests passing
- [x] All 40 PDF tests passing (no regressions)
- [x] TypeScript clean


🤖 Generated with [Claude Code](https://claude.com/claude-code)