### PR TITLE
feat: add schedule template PDF (F-614)

### DIFF
--- a/src/lib/pdf/__tests__/schedule-template.test.tsx
+++ b/src/lib/pdf/__tests__/schedule-template.test.tsx
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createElement } from 'react';
+
+vi.mock('@react-pdf/renderer', () => ({
+  Document: ({ children }: { children: React.ReactNode }) =>
+    createElement('document', null, children),
+  Page: ({ children, size }: { children: React.ReactNode; size: string }) =>
+    createElement('page', { 'data-size': size }, children),
+  Text: ({ children }: { children: React.ReactNode }) =>
+    createElement('text', null, children),
+  View: ({ children }: { children: React.ReactNode }) =>
+    createElement('view', null, children),
+  StyleSheet: {
+    create: <T extends Record<string, unknown>>(styles: T) => styles,
+  },
+}));
+
+const { ScheduleTemplate } = await import('../templates/schedule-template');
+
+describe('ScheduleTemplate', () => {
+  const defaultProps = {
+    propertyAddress: '東京都渋谷区神宮前1-2-3',
+    roomNumber: '301',
+    sellerName: '山田太郎',
+    buyerName: '佐藤花子',
+    moveOutDate: '2026年3月31日',
+    moveInDate: '2026年4月15日',
+    steps: [
+      {
+        event: '退去',
+        date: '2026年3月31日',
+        person: '前の住人',
+        notes: '荷物搬出完了',
+      },
+      { event: 'クリーニング', date: '2026年4月1日', person: '管理会社' },
+      {
+        event: '家具引き継ぎ確認',
+        date: '2026年4月10日',
+        person: '前の住人・次の住人',
+      },
+      { event: '鍵の引き渡し', date: '2026年4月14日', person: '管理会社' },
+      { event: '入居', date: '2026年4月15日', person: '次の住人' },
+    ],
+    createdDate: '2026年2月7日',
+  };
+
+  it('renders without error', () => {
+    const element = ScheduleTemplate(defaultProps);
+    expect(element).toBeTruthy();
+  });
+
+  it('includes property address', () => {
+    const element = ScheduleTemplate(defaultProps);
+    const json = JSON.stringify(element);
+    expect(json).toContain('東京都渋谷区神宮前1-2-3');
+  });
+
+  it('includes room number', () => {
+    const element = ScheduleTemplate(defaultProps);
+    const json = JSON.stringify(element);
+    expect(json).toContain('301');
+  });
+
+  it('includes seller and buyer names', () => {
+    const element = ScheduleTemplate(defaultProps);
+    const json = JSON.stringify(element);
+    expect(json).toContain('山田太郎');
+    expect(json).toContain('佐藤花子');
+  });
+
+  it('includes move-out and move-in dates', () => {
+    const element = ScheduleTemplate(defaultProps);
+    const json = JSON.stringify(element);
+    expect(json).toContain('2026年3月31日');
+    expect(json).toContain('2026年4月15日');
+  });
+
+  it('includes all schedule steps', () => {
+    const element = ScheduleTemplate(defaultProps);
+    const json = JSON.stringify(element);
+    expect(json).toContain('退去');
+    expect(json).toContain('クリーニング');
+    expect(json).toContain('家具引き継ぎ確認');
+    expect(json).toContain('鍵の引き渡し');
+    expect(json).toContain('入居');
+  });
+
+  it('includes step count in section title', () => {
+    const element = ScheduleTemplate(defaultProps);
+    const json = JSON.stringify(element);
+    expect(json).toContain('日程タイムライン');
+    expect(json).toContain(
+      '"children":["3. 日程タイムライン（",5,"ステップ）"]'
+    );
+  });
+
+  it('includes notes section', () => {
+    const element = ScheduleTemplate(defaultProps);
+    const json = JSON.stringify(element);
+    expect(json).toContain('注意事項');
+    expect(json).toContain('クリーニングは退去後');
+  });
+
+  it('includes approval section with three parties', () => {
+    const element = ScheduleTemplate(defaultProps);
+    const json = JSON.stringify(element);
+    expect(json).toContain('確認・承認');
+    expect(json).toContain('前の住人（甲）');
+    expect(json).toContain('次の住人（乙）');
+    expect(json).toContain('承認（管理会社）');
+  });
+
+  it('shows dash for missing step notes', () => {
+    const element = ScheduleTemplate(defaultProps);
+    const json = JSON.stringify(element);
+    expect(json).toContain('—');
+  });
+
+  it('uses A4 page size', () => {
+    const element = ScheduleTemplate(defaultProps);
+    const json = JSON.stringify(element);
+    expect(json).toContain('A4');
+  });
+
+  it('includes tsumugi branding', () => {
+    const element = ScheduleTemplate(defaultProps);
+    const json = JSON.stringify(element);
+    expect(json).toContain('tsumugi');
+  });
+
+  it('includes creation date', () => {
+    const element = ScheduleTemplate(defaultProps);
+    const json = JSON.stringify(element);
+    expect(json).toContain('2026年2月7日');
+  });
+
+  it('renders blank line when optional fields are not provided', () => {
+    const propsWithoutOptional = {
+      ...defaultProps,
+      buyerName: undefined,
+      moveOutDate: undefined,
+      moveInDate: undefined,
+    };
+    const element = ScheduleTemplate(propsWithoutOptional);
+    expect(element).toBeTruthy();
+    const json = JSON.stringify(element);
+    expect(json).not.toContain('佐藤花子');
+  });
+
+  it('shows 未定 for steps without date', () => {
+    const propsWithUndecidedDate = {
+      ...defaultProps,
+      steps: [{ event: 'テスト', person: '管理会社' }],
+    };
+    const element = ScheduleTemplate(propsWithUndecidedDate);
+    const json = JSON.stringify(element);
+    expect(json).toContain('未定');
+  });
+});

--- a/src/lib/pdf/index.ts
+++ b/src/lib/pdf/index.ts
@@ -3,3 +3,4 @@ export { renderPdf } from './render';
 export { SampleDocument } from './templates/sample';
 export { ConsultationDocument } from './templates/consultation-document';
 export { ConsentForm } from './templates/consent-form';
+export { ScheduleTemplate } from './templates/schedule-template';

--- a/src/lib/pdf/templates/schedule-template.tsx
+++ b/src/lib/pdf/templates/schedule-template.tsx
@@ -1,0 +1,341 @@
+import { Document, Page, Text, View, StyleSheet } from '@react-pdf/renderer';
+
+const styles = StyleSheet.create({
+  page: {
+    fontFamily: 'Noto Sans JP',
+    fontSize: 10,
+    padding: '36 44',
+    color: '#333333',
+    lineHeight: 1.5,
+  },
+  header: {
+    marginBottom: 16,
+    borderBottom: '2 solid #333333',
+    paddingBottom: 8,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'flex-end',
+  },
+  logo: {
+    fontSize: 14,
+    fontWeight: 700,
+    color: '#FF5A5F',
+  },
+  docId: {
+    fontSize: 8,
+    color: '#999999',
+  },
+  title: {
+    fontSize: 16,
+    fontWeight: 700,
+    textAlign: 'center',
+    marginBottom: 20,
+  },
+  section: {
+    marginBottom: 14,
+  },
+  sectionTitle: {
+    fontSize: 11,
+    fontWeight: 700,
+    marginBottom: 6,
+    backgroundColor: '#f5f5f5',
+    padding: '4 8',
+  },
+  row: {
+    flexDirection: 'row',
+    borderBottom: '1 solid #eeeeee',
+    paddingVertical: 4,
+    paddingHorizontal: 8,
+  },
+  label: {
+    width: 110,
+    fontSize: 9,
+    color: '#666666',
+    fontWeight: 700,
+  },
+  value: {
+    flex: 1,
+    fontSize: 10,
+  },
+  blankLine: {
+    flex: 1,
+    fontSize: 10,
+    borderBottom: '1 dotted #cccccc',
+    minHeight: 16,
+  },
+  timelineHeader: {
+    flexDirection: 'row',
+    backgroundColor: '#f5f5f5',
+    borderBottom: '1 solid #cccccc',
+    paddingVertical: 5,
+    paddingHorizontal: 8,
+  },
+  timelineRow: {
+    flexDirection: 'row',
+    borderBottom: '1 solid #eeeeee',
+    paddingVertical: 6,
+    paddingHorizontal: 8,
+    minHeight: 24,
+  },
+  timelineColStep: {
+    width: '8%',
+    fontSize: 9,
+  },
+  timelineColEvent: {
+    width: '28%',
+    fontSize: 9,
+  },
+  timelineColDate: {
+    width: '22%',
+    fontSize: 9,
+  },
+  timelineColPerson: {
+    width: '18%',
+    fontSize: 9,
+  },
+  timelineColNotes: {
+    width: '24%',
+    fontSize: 9,
+  },
+  headerText: {
+    fontSize: 8,
+    fontWeight: 700,
+    color: '#666666',
+  },
+  note: {
+    fontSize: 9,
+    marginBottom: 6,
+    paddingLeft: 8,
+    lineHeight: 1.6,
+  },
+  approvalBlock: {
+    marginTop: 12,
+    borderTop: '1 solid #eeeeee',
+    paddingTop: 12,
+  },
+  approvalRow: {
+    flexDirection: 'row',
+    marginBottom: 16,
+    alignItems: 'flex-end',
+  },
+  approvalLabel: {
+    width: 100,
+    fontSize: 9,
+    fontWeight: 700,
+    color: '#666666',
+  },
+  approvalLine: {
+    flex: 1,
+    borderBottom: '1 solid #333333',
+    minHeight: 20,
+    marginRight: 16,
+  },
+  approvalDate: {
+    width: 140,
+    fontSize: 9,
+    color: '#666666',
+  },
+  dateLine: {
+    borderBottom: '1 dotted #cccccc',
+    minHeight: 16,
+    width: 100,
+  },
+  footer: {
+    position: 'absolute',
+    bottom: 28,
+    left: 44,
+    right: 44,
+    borderTop: '1 solid #eeeeee',
+    paddingTop: 6,
+    fontSize: 7,
+    color: '#999999',
+    textAlign: 'center',
+  },
+});
+
+interface ScheduleStep {
+  event: string;
+  date?: string;
+  person: string;
+  notes?: string;
+}
+
+interface ScheduleTemplateProps {
+  propertyAddress: string;
+  roomNumber?: string;
+  sellerName: string;
+  buyerName?: string;
+  moveOutDate?: string;
+  moveInDate?: string;
+  steps: ScheduleStep[];
+  createdDate: string;
+}
+
+export function ScheduleTemplate({
+  propertyAddress,
+  roomNumber,
+  sellerName,
+  buyerName,
+  moveOutDate,
+  moveInDate,
+  steps,
+  createdDate,
+}: ScheduleTemplateProps) {
+  return (
+    <Document>
+      <Page size="A4" style={styles.page}>
+        {/* Header */}
+        <View style={styles.header}>
+          <Text style={styles.logo}>tsumugi</Text>
+          <Text style={styles.docId}>作成日: {createdDate}</Text>
+        </View>
+
+        {/* Title */}
+        <Text style={styles.title}>引き継ぎ日程調整表</Text>
+
+        {/* Property Info */}
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>1. 物件情報</Text>
+          <View style={styles.row}>
+            <Text style={styles.label}>物件所在地</Text>
+            <Text style={styles.value}>{propertyAddress}</Text>
+          </View>
+          <View style={styles.row}>
+            <Text style={styles.label}>部屋番号</Text>
+            {roomNumber ? (
+              <Text style={styles.value}>{roomNumber}</Text>
+            ) : (
+              <View style={styles.blankLine} />
+            )}
+          </View>
+        </View>
+
+        {/* Parties & Key Dates */}
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>2. 関係者・主要日程</Text>
+          <View style={styles.row}>
+            <Text style={styles.label}>前の住人（甲）</Text>
+            {sellerName ? (
+              <Text style={styles.value}>{sellerName}</Text>
+            ) : (
+              <View style={styles.blankLine} />
+            )}
+          </View>
+          <View style={styles.row}>
+            <Text style={styles.label}>次の住人（乙）</Text>
+            {buyerName ? (
+              <Text style={styles.value}>{buyerName}</Text>
+            ) : (
+              <View style={styles.blankLine} />
+            )}
+          </View>
+          <View style={styles.row}>
+            <Text style={styles.label}>退去予定日</Text>
+            {moveOutDate ? (
+              <Text style={styles.value}>{moveOutDate}</Text>
+            ) : (
+              <View style={styles.blankLine} />
+            )}
+          </View>
+          <View style={styles.row}>
+            <Text style={styles.label}>入居予定日</Text>
+            {moveInDate ? (
+              <Text style={styles.value}>{moveInDate}</Text>
+            ) : (
+              <View style={styles.blankLine} />
+            )}
+          </View>
+        </View>
+
+        {/* Schedule Timeline */}
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>
+            3. 日程タイムライン（{steps.length}ステップ）
+          </Text>
+          <View style={styles.timelineHeader}>
+            <Text style={[styles.timelineColStep, styles.headerText]}>No.</Text>
+            <Text style={[styles.timelineColEvent, styles.headerText]}>
+              イベント
+            </Text>
+            <Text style={[styles.timelineColDate, styles.headerText]}>
+              予定日
+            </Text>
+            <Text style={[styles.timelineColPerson, styles.headerText]}>
+              担当者
+            </Text>
+            <Text style={[styles.timelineColNotes, styles.headerText]}>
+              備考
+            </Text>
+          </View>
+          {steps.map((step, index) => (
+            <View key={index} style={styles.timelineRow}>
+              <Text style={styles.timelineColStep}>{index + 1}</Text>
+              <Text style={styles.timelineColEvent}>{step.event}</Text>
+              <Text style={styles.timelineColDate}>{step.date ?? '未定'}</Text>
+              <Text style={styles.timelineColPerson}>{step.person}</Text>
+              <Text style={styles.timelineColNotes}>{step.notes ?? '—'}</Text>
+            </View>
+          ))}
+        </View>
+
+        {/* Notes */}
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>4. 注意事項</Text>
+          <Text style={styles.note}>
+            (1)
+            各日程は関係者全員の合意の上で確定するものとし、変更がある場合は速やかに全関係者に連絡すること。
+          </Text>
+          <Text style={styles.note}>
+            (2) クリーニングは退去後、入居前に完了する必要があります。
+          </Text>
+          <Text style={styles.note}>
+            (3)
+            家具引き継ぎの確認は、前の住人と次の住人が立ち会いの上で行うことを推奨します。
+          </Text>
+          <Text style={styles.note}>
+            (4) 鍵の引き渡しは管理会社を通じて行うものとします。
+          </Text>
+        </View>
+
+        {/* Approval */}
+        <View style={styles.approvalBlock}>
+          <Text style={styles.sectionTitle}>5. 確認・承認</Text>
+
+          <View style={styles.approvalRow}>
+            <Text style={styles.approvalLabel}>前の住人（甲）</Text>
+            <View style={styles.approvalLine} />
+            <View style={{ flexDirection: 'row', alignItems: 'flex-end' }}>
+              <Text style={styles.approvalDate}>日付: </Text>
+              <View style={styles.dateLine} />
+            </View>
+          </View>
+
+          <View style={styles.approvalRow}>
+            <Text style={styles.approvalLabel}>次の住人（乙）</Text>
+            <View style={styles.approvalLine} />
+            <View style={{ flexDirection: 'row', alignItems: 'flex-end' }}>
+              <Text style={styles.approvalDate}>日付: </Text>
+              <View style={styles.dateLine} />
+            </View>
+          </View>
+
+          <View style={styles.approvalRow}>
+            <Text style={styles.approvalLabel}>承認（管理会社）</Text>
+            <View style={styles.approvalLine} />
+            <View style={{ flexDirection: 'row', alignItems: 'flex-end' }}>
+              <Text style={styles.approvalDate}>日付: </Text>
+              <View style={styles.dateLine} />
+            </View>
+          </View>
+        </View>
+
+        {/* Footer */}
+        <View style={styles.footer} fixed>
+          <Text>
+            tsumugi 引き継ぎ日程調整表 | © {new Date().getFullYear()} tsumugi
+          </Text>
+        </View>
+      </Page>
+    </Document>
+  );
+}


### PR DESCRIPTION
## Summary
- Add `ScheduleTemplate` PDF template for 引き継ぎ日程調整表 (handover schedule coordination)
- Template includes: property info, parties & key dates (move-out/move-in), timeline table with step/event/date/person/notes, notes section, and approval block for 3 parties
- Export from `@/lib/pdf` barrel file
- 15 unit tests covering all sections, edge cases (missing buyer, undecided dates, missing notes)

## Test plan
- [x] 15 unit tests passing
- [x] All 55 PDF tests passing (no regressions)
- [x] TypeScript clean


🤖 Generated with [Claude Code](https://claude.com/claude-code)