### PR TITLE
feat: add landlord consent badge with status management UI

### DIFF
--- a/src/app/listing/page.tsx
+++ b/src/app/listing/page.tsx
@@ -17,6 +17,7 @@ import {
   Home,
 } from 'lucide-react';
 import { InquiryList } from '@/components/admin/inquiry-list';
+import { ConsentBadge } from '@/components/consent-badge';
 
 // 無限スクロール用の画像データ（Unsplash - 明るいインテリア・部屋の写真）
 const scrollImages = {
@@ -109,6 +110,7 @@ function ListingCard({
     status: string;
     roomPhotos?: string[];
     publishedAt?: string;
+    consentStatus?: string;
   };
   onDelete: (id: string) => void;
 }) {
@@ -131,7 +133,7 @@ function ListingCard({
           </div>
         )}
         {/* ステータスバッジ */}
-        <div className="absolute top-3 left-3">
+        <div className="absolute top-3 left-3 flex flex-col gap-1.5">
           <span
             className={`px-3 py-1 rounded-full text-xs font-medium ${
               listing.status === 'published'
@@ -141,6 +143,19 @@ function ListingCard({
           >
             {listing.status === 'published' ? '公開中' : '下書き'}
           </span>
+          {listing.consentStatus && (
+            <ConsentBadge
+              status={
+                listing.consentStatus as
+                  | 'pending'
+                  | 'conditional'
+                  | 'approved'
+                  | 'rejected'
+                  | 'expired'
+              }
+              variant="inline"
+            />
+          )}
         </div>
         {/* メニューボタン */}
         <div className="absolute top-3 right-3">

--- a/src/app/listings/[id]/page.tsx
+++ b/src/app/listings/[id]/page.tsx
@@ -13,8 +13,6 @@ import {
 import {
   ArrowLeft,
   Home,
-  CheckCircle2,
-  XCircle,
   BedDouble,
   Sofa,
   Monitor,
@@ -28,6 +26,7 @@ import {
 } from 'lucide-react';
 import { isUrgentMoveIn } from '@/lib/utils';
 import { UrgentMoveInBadge } from '@/components/urgent-move-in-badge';
+import { ConsentBadge } from '@/components/consent-badge';
 
 const FURNITURE_ICONS: Record<string, typeof BedDouble> = {
   bed: BedDouble,
@@ -111,6 +110,13 @@ export default async function PropertyDetailPage({
                   {isUrgentMoveIn(property.moveOutDate) && (
                     <UrgentMoveInBadge variant="inline" />
                   )}
+                  {property.consentStatus &&
+                    property.consentStatus !== 'pending' && (
+                      <ConsentBadge
+                        status={property.consentStatus}
+                        variant="inline"
+                      />
+                    )}
                 </div>
                 <p className="mt-1 text-base font-normal text-foreground">
                   {[

--- a/src/components/__tests__/consent-badge.test.tsx
+++ b/src/components/__tests__/consent-badge.test.tsx
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createElement } from 'react';
+
+vi.mock('lucide-react', () => ({
+  CheckCircle2: ({ children, ...props }: Record<string, unknown>) =>
+    createElement('svg', { 'data-icon': 'check-circle-2', ...props }, children),
+  AlertCircle: ({ children, ...props }: Record<string, unknown>) =>
+    createElement('svg', { 'data-icon': 'alert-circle', ...props }, children),
+  XCircle: ({ children, ...props }: Record<string, unknown>) =>
+    createElement('svg', { 'data-icon': 'x-circle', ...props }, children),
+  Clock: ({ children, ...props }: Record<string, unknown>) =>
+    createElement('svg', { 'data-icon': 'clock', ...props }, children),
+  ShieldQuestion: ({ children, ...props }: Record<string, unknown>) =>
+    createElement(
+      'svg',
+      { 'data-icon': 'shield-question', ...props },
+      children
+    ),
+}));
+
+vi.mock('@/lib/utils', () => ({
+  cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
+}));
+
+const { ConsentBadge } = await import('../consent-badge');
+
+describe('ConsentBadge', () => {
+  describe('inline variant', () => {
+    it('renders approved status with green styling and checkmark', () => {
+      const element = ConsentBadge({ status: 'approved', variant: 'inline' });
+      const json = JSON.stringify(element);
+      expect(json).toContain('大家承認済み');
+      expect(json).toContain('bg-green-50');
+      expect(json).toContain('text-green-700');
+      expect(json).toContain('✓');
+    });
+
+    it('renders pending status with gray styling', () => {
+      const element = ConsentBadge({ status: 'pending', variant: 'inline' });
+      const json = JSON.stringify(element);
+      expect(json).toContain('要確認');
+      expect(json).toContain('bg-gray-100');
+      expect(json).toContain('text-gray-600');
+    });
+
+    it('renders conditional status with yellow styling', () => {
+      const element = ConsentBadge({
+        status: 'conditional',
+        variant: 'inline',
+      });
+      const json = JSON.stringify(element);
+      expect(json).toContain('条件付き承認');
+      expect(json).toContain('bg-yellow-50');
+      expect(json).toContain('text-yellow-700');
+    });
+
+    it('renders rejected status with red styling', () => {
+      const element = ConsentBadge({ status: 'rejected', variant: 'inline' });
+      const json = JSON.stringify(element);
+      expect(json).toContain('承認不可');
+      expect(json).toContain('bg-red-50');
+      expect(json).toContain('text-red-700');
+    });
+
+    it('renders expired status with gray styling', () => {
+      const element = ConsentBadge({ status: 'expired', variant: 'inline' });
+      const json = JSON.stringify(element);
+      expect(json).toContain('期限切れ');
+      expect(json).toContain('bg-gray-100');
+      expect(json).toContain('text-gray-500');
+    });
+  });
+
+  describe('overlay variant', () => {
+    it('renders approved overlay with green background', () => {
+      const element = ConsentBadge({ status: 'approved', variant: 'overlay' });
+      const json = JSON.stringify(element);
+      expect(json).toContain('大家承認済み');
+      expect(json).toContain('bg-green-600');
+      expect(json).toContain('absolute');
+    });
+
+    it('renders rejected overlay with red background', () => {
+      const element = ConsentBadge({ status: 'rejected', variant: 'overlay' });
+      const json = JSON.stringify(element);
+      expect(json).toContain('承認不可');
+      expect(json).toContain('bg-red-600');
+    });
+
+    it('defaults to overlay variant', () => {
+      const element = ConsentBadge({ status: 'approved' });
+      const json = JSON.stringify(element);
+      expect(json).toContain('absolute');
+      expect(json).toContain('shadow-md');
+    });
+  });
+
+  describe('custom className', () => {
+    it('accepts and applies custom className', () => {
+      const element = ConsentBadge({
+        status: 'approved',
+        variant: 'inline',
+        className: 'custom-class',
+      });
+      const json = JSON.stringify(element);
+      expect(json).toContain('custom-class');
+    });
+  });
+
+  describe('icon rendering', () => {
+    it('renders an icon element for each status', () => {
+      const statuses: Array<
+        'pending' | 'conditional' | 'approved' | 'rejected' | 'expired'
+      > = ['pending', 'conditional', 'approved', 'rejected', 'expired'];
+      for (const status of statuses) {
+        const element = ConsentBadge({ status, variant: 'inline' });
+        const json = JSON.stringify(element);
+        // Each badge should contain an icon with h-3 w-3 class
+        expect(json).toContain('h-3 w-3');
+      }
+    });
+  });
+
+  describe('checkmark prefix', () => {
+    it('only shows checkmark for approved status', () => {
+      const approved = ConsentBadge({ status: 'approved', variant: 'inline' });
+      const pending = ConsentBadge({ status: 'pending', variant: 'inline' });
+      expect(JSON.stringify(approved)).toContain('✓');
+      expect(JSON.stringify(pending)).not.toContain('✓');
+    });
+  });
+});

--- a/src/components/consent-badge.tsx
+++ b/src/components/consent-badge.tsx
@@ -1,0 +1,95 @@
+import {
+  CheckCircle2,
+  AlertCircle,
+  XCircle,
+  Clock,
+  ShieldQuestion,
+} from 'lucide-react';
+import { cn } from '@/lib/utils';
+import type { ConsentStatus } from '@/lib/data';
+
+interface ConsentBadgeProps {
+  status: ConsentStatus;
+  className?: string;
+  variant?: 'overlay' | 'inline';
+}
+
+const CONSENT_CONFIG: Record<
+  ConsentStatus,
+  {
+    label: string;
+    icon: typeof CheckCircle2;
+    overlayClass: string;
+    inlineClass: string;
+  }
+> = {
+  pending: {
+    label: '要確認',
+    icon: ShieldQuestion,
+    overlayClass: 'bg-gray-500 text-white',
+    inlineClass: 'bg-gray-100 text-gray-600',
+  },
+  conditional: {
+    label: '条件付き承認',
+    icon: AlertCircle,
+    overlayClass: 'bg-yellow-500 text-white',
+    inlineClass: 'bg-yellow-50 text-yellow-700',
+  },
+  approved: {
+    label: '大家承認済み',
+    icon: CheckCircle2,
+    overlayClass: 'bg-green-600 text-white',
+    inlineClass: 'bg-green-50 text-green-700',
+  },
+  rejected: {
+    label: '承認不可',
+    icon: XCircle,
+    overlayClass: 'bg-red-600 text-white',
+    inlineClass: 'bg-red-50 text-red-700',
+  },
+  expired: {
+    label: '期限切れ',
+    icon: Clock,
+    overlayClass: 'bg-gray-400 text-white',
+    inlineClass: 'bg-gray-100 text-gray-500',
+  },
+};
+
+export function ConsentBadge({
+  status,
+  className,
+  variant = 'overlay',
+}: ConsentBadgeProps) {
+  const config = CONSENT_CONFIG[status];
+  const Icon = config.icon;
+
+  if (variant === 'overlay') {
+    return (
+      <div
+        className={cn(
+          'absolute left-3 top-3 z-10 flex items-center gap-1 rounded-full px-2.5 py-1 text-xs font-semibold shadow-md',
+          config.overlayClass,
+          className
+        )}
+      >
+        <Icon className="h-3 w-3" />
+        {status === 'approved' && '✓ '}
+        {config.label}
+      </div>
+    );
+  }
+
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-xs font-semibold',
+        config.inlineClass,
+        className
+      )}
+    >
+      <Icon className="h-3 w-3" />
+      {status === 'approved' && '✓ '}
+      {config.label}
+    </span>
+  );
+}

--- a/src/components/property-card.tsx
+++ b/src/components/property-card.tsx
@@ -9,6 +9,7 @@ import { Heart, ChevronLeft, ChevronRight } from 'lucide-react';
 import type { Property } from '@/lib/data';
 import { isUrgentMoveIn } from '@/lib/utils';
 import { UrgentMoveInBadge } from '@/components/urgent-move-in-badge';
+import { ConsentBadge } from '@/components/consent-badge';
 
 function parseLocation(neighborhood: string | undefined): {
   ward?: string;
@@ -75,6 +76,17 @@ export function PropertyCard({ property }: PropertyCardProps) {
 
         {/* 即入居可能バッジ（F-507） */}
         {isUrgentMoveIn(property.moveOutDate) && <UrgentMoveInBadge />}
+
+        {/* 大家承認バッジ（§7.4） */}
+        {property.consentStatus === 'approved' && (
+          <ConsentBadge
+            status="approved"
+            variant="overlay"
+            className={
+              isUrgentMoveIn(property.moveOutDate) ? 'top-10' : undefined
+            }
+          />
+        )}
 
         {/* Heart button */}
         <button

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -187,6 +187,14 @@ export type LargeApplianceType =
   | 'dishwasher';
 
 // 大家承諾情報
+// 大家承認ステータス（§7.4）
+export type ConsentStatus =
+  | 'pending'
+  | 'conditional'
+  | 'approved'
+  | 'rejected'
+  | 'expired';
+
 export interface LandlordConsent {
   hasLandlordConsent: boolean;
 }
@@ -223,6 +231,7 @@ export interface UserListing {
   furniture?: LargeFurnitureType[]; // 大型家具（旧形式、互換性のため）
   furnitureItems?: FurnitureItem[]; // 家具アイテム（写真付き）
   story?: string;
+  consentStatus?: ConsentStatus; // 大家承認ステータス（§7.4）
   // 公開前確認
   landlordConsent?: LandlordConsent; // 大家承諾
   liabilityTerms?: LiabilityTerms; // 責任区分
@@ -249,6 +258,7 @@ export interface Property {
   furniture?: LargeFurnitureType[]; // 引き継ぎ対象の大型家具
   moveOutDate?: string; // 退去日（F-501）
   status: 'draft' | 'public';
+  consentStatus?: ConsentStatus; // 大家承認ステータス（§7.4）
   // 以下は詳細ページ用（MVP後に追加検討）
   summary?: string;
   furnitureDescription?: string;
@@ -311,6 +321,7 @@ export const properties: Property[] = [
       'ヴィンテージのチェスト、手作りの本棚、レコードプレーヤー。壁にかかる大きなタペストリーはお気に入りのアーティストの作品。スケートボードやアート作品もそのままお使いいただけます。',
     moveOutDate: '2026-03-01',
     status: 'public',
+    consentStatus: 'approved',
     story:
       'グラフィックデザイナーとして活動しながら、この部屋を自分だけのギャラリーのように育ててきました。窓辺の植物たちに水をやり、好きなレコードをかけながら作業する日々。海外での仕事が決まり、この空間を大切にしてくれる方に引き継ぎたいと思っています。',
     conditions:
@@ -412,6 +423,7 @@ export const properties: Property[] = [
     furnitureDescription:
       'Marshallのスピーカー、DJ機材一式（ターンテーブル、ミキサー）、レコード棚。深夜でも音を出せる防音対策済み。シンプルなベッドフレーム、カフェテーブルとチェア。',
     status: 'public',
+    consentStatus: 'conditional',
     story:
       'DJとして活動しながら、週末は自宅でイベントを開催してきました。コンクリートの音響と、機材を囲んだ空間が最高です。海外ツアーが決まり、同じように音楽を愛する方に使ってもらえたら嬉しいです。レコードコレクションも一部そのまま使えます。',
     conditions:
@@ -520,6 +532,7 @@ export const properties: Property[] = [
     furnitureDescription:
       '木製のヴィンテージデスク、レトロな照明、古い本棚。長年かけて集めた古道具たちがこの空間を彩っています。',
     status: 'public',
+    consentStatus: 'pending',
     story:
       '古着屋を営みながら、仕事帰りに少しずつ集めた家具たち。この部屋で過ごす時間が一番落ち着きます。店舗を移転することになり、この空間を気に入ってくれる方に譲りたいです。',
     conditions: 'ヴィンテージ品を大切にしてくれる方。喫煙不可。',


### PR DESCRIPTION
## Summary

- Add `ConsentStatus` type (`pending` | `conditional` | `approved` | `rejected` | `expired`) to `Property` and `UserListing` interfaces
- Create `ConsentBadge` component with color-coded status display and Lucide icons
- Integrate badge in property detail page (inline, next to title)
- Integrate badge in property cards (overlay on approved properties)
- Integrate badge in listing management page (inline below publish status)
- Add mock consent status data to 3 properties for demonstration

## Test plan

- [x] 11 unit tests covering all statuses, variants, styling, icons, and checkmark prefix
- [x] All 188 existing tests pass (no regressions)
- [ ] Visual verification of badge on property detail, property card, and listing management pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)