### PR TITLE
fix: replace クリエイター with 前の住人 in all UI text

### DIFF
--- a/src/app/account/edit/page.tsx
+++ b/src/app/account/edit/page.tsx
@@ -93,7 +93,7 @@ export default function AccountEditPage() {
       avatarUrl: formData.avatarUrl || undefined,
     };
 
-    // クリエイタープロフィールの更新
+    // 前の住人プロフィールの更新
     if (user.isSeller && user.sellerProfile) {
       updates.sellerProfile = {
         ...user.sellerProfile,
@@ -283,12 +283,12 @@ export default function AccountEditPage() {
               />
             </div>
 
-            {/* クリエイタープロフィール（セラーのみ） */}
+            {/* 前の住人プロフィール（セラーのみ） */}
             {user.isSeller && (
               <>
                 <div className="pt-6">
                   <h2 className="text-xl font-semibold text-foreground mb-6">
-                    クリエイタープロフィール
+                    前の住人プロフィール
                   </h2>
                 </div>
 

--- a/src/app/account/page.tsx
+++ b/src/app/account/page.tsx
@@ -84,7 +84,7 @@ export default function AccountPage() {
                     {user.name}
                   </h2>
                   <p className="text-sm text-muted-foreground">
-                    {user.isSeller ? 'クリエイター' : '入居希望者'}
+                    {user.isSeller ? '前の住人' : '入居希望者'}
                   </p>
                   <p className="mt-1 text-sm text-coral font-medium">
                     プロフィールを編集
@@ -142,12 +142,12 @@ export default function AccountPage() {
             </div>
           </div>
 
-          {/* クリエイタープロフィール（ホストのみ） */}
+          {/* 前の住人プロフィール（ホストのみ） */}
           {user.isSeller && user.sellerProfile && (
             <div className="mb-6 rounded-xl border border-border bg-background shadow-sm">
               <div className="border-b border-border p-4">
                 <h3 className="font-semibold text-foreground">
-                  クリエイタープロフィール
+                  前の住人プロフィール
                 </h3>
               </div>
               <div className="divide-y divide-border">
@@ -200,9 +200,7 @@ export default function AccountPage() {
                 <div className="flex items-center gap-3 p-4">
                   <Calendar className="h-5 w-5 text-muted-foreground" />
                   <div className="flex-1">
-                    <p className="text-sm text-muted-foreground">
-                      クリエイター登録日
-                    </p>
+                    <p className="text-sm text-muted-foreground">登録日</p>
                     <p className="text-foreground">
                       {formatDate(user.sellerProfile.sellerSince)}
                     </p>
@@ -212,7 +210,7 @@ export default function AccountPage() {
             </div>
           )}
 
-          {/* クリエイターになる（非ホストのみ） */}
+          {/* 前の住人になる（非ホストのみ） */}
           {!user.isSeller && (
             <Link
               href="/listing"
@@ -224,7 +222,7 @@ export default function AccountPage() {
                 </div>
                 <div>
                   <p className="font-semibold text-foreground">
-                    クリエイターになる
+                    前の住人になる
                   </p>
                   <p className="text-sm text-muted-foreground">
                     あなたの暮らしを次の人へ引き継ぎませんか？

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -39,19 +39,19 @@ export default function TermsPage() {
             <ol className="list-decimal list-inside space-y-2 text-muted-foreground">
               <li>
                 <strong>「本サービス」</strong>
-                とは、クリエイターが作り上げた暮らし（家具・インテリアを含む居住空間）を次のクリエイターへ引き継ぐためのマッチングプラットフォームを指します。
+                とは、前の住人が作り上げた暮らし（家具・インテリアを含む居住空間）を次の住人へ引き継ぐためのマッチングプラットフォームを指します。
               </li>
               <li>
                 <strong>「ユーザー」</strong>
                 とは、本サービスを利用するすべての方を指します。
               </li>
               <li>
-                <strong>「クリエイター」</strong>
+                <strong>「前の住人」</strong>
                 とは、本サービスにおいて自身の居住空間を出品する方を指します。
               </li>
               <li>
                 <strong>「引き継ぎ希望者」</strong>
-                とは、本サービスにおいてクリエイターの居住空間の引き継ぎを希望する方を指します。
+                とは、本サービスにおいて前の住人の居住空間の引き継ぎを希望する方を指します。
               </li>
               <li>
                 <strong>「物品」</strong>
@@ -91,7 +91,7 @@ export default function TermsPage() {
             </h2>
             <ol className="list-decimal list-inside space-y-2 text-muted-foreground">
               <li>
-                本サービスは、クリエイターと引き継ぎ希望者のマッチングの場を提供するものです。
+                本サービスは、前の住人と引き継ぎ希望者のマッチングの場を提供するものです。
               </li>
               <li>
                 当社は、ユーザー間の取引の当事者とはならず、取引に関する交渉、契約締結、履行等はユーザー間で直接行うものとします。
@@ -104,11 +104,11 @@ export default function TermsPage() {
 
           <section>
             <h2 className="text-xl font-semibold mt-8 mb-4">
-              第5条（クリエイターの責任）
+              第5条（前の住人の責任）
             </h2>
             <ol className="list-decimal list-inside space-y-2 text-muted-foreground">
               <li>
-                クリエイターは、出品にあたり以下の事項を遵守するものとします。
+                前の住人は、出品にあたり以下の事項を遵守するものとします。
                 <ul className="list-disc list-inside ml-4 mt-2 space-y-1">
                   <li>
                     物件の所有者（大家）に対し、本サービスを通じた引き継ぎについて事前に説明し、承諾を得ること
@@ -122,7 +122,7 @@ export default function TermsPage() {
                 </ul>
               </li>
               <li>
-                クリエイターは、出品する物品の安全性について責任を負うものとします。
+                前の住人は、出品する物品の安全性について責任を負うものとします。
               </li>
               <li>
                 以下の物品の出品は禁止します。

--- a/src/components/auth/become-seller-dialog.tsx
+++ b/src/components/auth/become-seller-dialog.tsx
@@ -92,7 +92,7 @@ export function BecomeSellerDialog({
             </button>
           )}
           <DialogTitle className="text-center text-base font-semibold">
-            クリエイターになる
+            前の住人になる
           </DialogTitle>
         </DialogHeader>
 
@@ -210,7 +210,7 @@ export function BecomeSellerDialog({
               <div>
                 <h2 className="text-xl font-semibold mb-2">確認</h2>
                 <p className="text-sm text-muted-foreground">
-                  以下の内容でクリエイターとして登録します
+                  以下の内容で前の住人として登録します
                 </p>
               </div>
 
@@ -250,7 +250,7 @@ export function BecomeSellerDialog({
                 ) : (
                   <>
                     <Check className="mr-2 h-4 w-4" />
-                    クリエイターになる
+                    前の住人になる
                   </>
                 )}
               </Button>

--- a/src/components/auth/become-seller-flow.tsx
+++ b/src/components/auth/become-seller-flow.tsx
@@ -297,7 +297,7 @@ export function BecomeSellerFlow({
             <div className="flex flex-1 flex-col justify-center px-12 py-16 lg:px-24">
               <p className="text-sm text-muted-foreground mb-2">ステップ1</p>
               <h1 className="text-4xl font-semibold mb-6">
-                クリエイターとして
+                前の住人として
                 <br />
                 登録する
               </h1>
@@ -479,7 +479,7 @@ export function BecomeSellerFlow({
               <p className="text-sm text-muted-foreground mb-2">ステップ3</p>
               <h1 className="text-4xl font-semibold mb-6">登録内容の確認</h1>
               <p className="text-muted-foreground mb-8">
-                以下の内容でクリエイターとして登録します
+                以下の内容で前の住人として登録します
               </p>
               <div className="space-y-4 rounded-xl border p-6 max-w-md">
                 <div>
@@ -560,7 +560,7 @@ export function BecomeSellerFlow({
               ) : (
                 <>
                   <Check className="mr-2 h-4 w-4" />
-                  クリエイターになる
+                  前の住人になる
                 </>
               )}
             </Button>

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -58,7 +58,7 @@ export function Header() {
         </Link>
 
         <div className="flex items-center gap-2">
-          {/* クリエイターになる / クリエイターモード Button - 非ホストのみ表示 */}
+          {/* 前の住人になる / 引き継ぎ側モード Button - 非ホストのみ表示 */}
           {(!user || !user.isSeller) && (
             <button
               onClick={handleBecomeCreatorClick}


### PR DESCRIPTION
## Summary

- Replace the internal term "クリエイター" with the correct user-facing term "前の住人" across all UI-visible text
- Covers account page, account edit page, terms of service, seller registration flow/dialog, and header comment
- Mock data occupations (映像クリエイター, DIYクリエイター) are intentionally kept as they refer to actual job titles

## Modified Files

| File | Changes |
| --- | --- |
| `src/app/account/page.tsx` | Role label, profile section, registration button |
| `src/app/account/edit/page.tsx` | Profile section header, comment |
| `src/app/terms/page.tsx` | Legal terminology throughout |
| `src/components/auth/become-seller-flow.tsx` | Registration flow headings, confirmation text, button |
| `src/components/auth/become-seller-dialog.tsx` | Dialog title, confirmation text, button |
| `src/components/header.tsx` | Code comment |

## Test plan

- [x] All 240 unit tests passing
- [ ] Verify no "クリエイター" appears in UI (except occupation choices and mock data)
- [ ] Verify terms page reads correctly with new terminology

🤖 Generated with [Claude Code](https://claude.com/claude-code)