### PR TITLE
feat: add messaging service for viewing scheduling

### DIFF
--- a/src/lib/__tests__/messaging.test.ts
+++ b/src/lib/__tests__/messaging.test.ts
@@ -146,6 +146,20 @@ describe('messaging service', () => {
       expect(fetched!.id).toBe(proposal.id);
     });
 
+    it('rejects selecting a date on already-confirmed proposal', () => {
+      const thread = createThread('prop-1', 'seller-1', 'buyer-1');
+      const dates = [
+        '2026-02-15T10:00:00',
+        '2026-02-16T14:00:00',
+        '2026-02-17T11:00:00',
+      ];
+      const proposal = sendDateProposal(thread.id, 'seller-1', dates);
+      selectDate(proposal.id, '2026-02-16T14:00:00');
+      expect(() => selectDate(proposal.id, '2026-02-15T10:00:00')).toThrow(
+        'この日程提案は既に確定または期限切れです'
+      );
+    });
+
     it('returns undefined for nonexistent proposal', () => {
       expect(getDateProposal('nonexistent')).toBeUndefined();
     });

--- a/src/lib/messaging.ts
+++ b/src/lib/messaging.ts
@@ -161,6 +161,10 @@ export function selectDate(
     throw new Error('日程提案が見つかりません');
   }
 
+  if (proposal.status !== 'pending') {
+    throw new Error('この日程提案は既に確定または期限切れです');
+  }
+
   if (!proposal.candidateDates.includes(selectedDate)) {
     throw new Error('選択された日時は候補に含まれていません');
   }


### PR DESCRIPTION
## Summary

- Implement messaging data layer for viewing schedule coordination (内見日程調整)
- Thread model: 1 thread per property × seller × buyer combination (deduplication)
- Message types: text, template (date proposals), system (confirmations)
- Date proposal flow: seller proposes 3 candidates → buyer selects 1 → confirmed
- Status validation: prevents re-confirming already-confirmed/expired proposals
- All functions use immutable patterns (no mutation)
- In-memory store (mock, to be replaced with DB in future)

## Test plan

- [x] 14 unit tests covering all messaging functions
- [x] Thread creation and deduplication
- [x] Message sending and retrieval in chronological order
- [x] Date proposal creation, selection, and rejection of invalid dates
- [x] Status validation (already-confirmed proposal rejection)
- [x] Addressed review feedback: added `proposal.status !== 'pending'` guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)