### PR TITLE
chore: add recommended VS Code extensions to devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,7 +15,15 @@
         "eamodio.gitlens",
         "GitHub.vscode-github-actions",
         "ms-azuretools.vscode-containers",
-        "ms-playwright.playwright"
+        "ms-playwright.playwright",
+        "usernamehw.errorlens",
+        "bradlc.vscode-tailwindcss",
+        "pranaygp.vscode-css-peek",
+        "GitHub.vscode-pull-request-github",
+        "Gruntfuggly.todo-tree",
+        "yzhang.markdown-all-in-one",
+        "mushan.vscode-paste-image",
+        "tonybaloney.vscode-pets"
       ],
       "settings": {
         "editor.formatOnSave": true,


### PR DESCRIPTION
## Summary
- Adds useful VS Code extensions to the devcontainer configuration
- Improves developer experience with better error visibility, Tailwind support, and productivity tools

## Changes
- `.devcontainer/devcontainer.json`: Added 8 extensions
  - `usernamehw.errorlens` - Inline error/warning display
  - `bradlc.vscode-tailwindcss` - Tailwind CSS IntelliSense
  - `pranaygp.vscode-css-peek` - CSS class peek/goto
  - `GitHub.vscode-pull-request-github` - GitHub PR integration
  - `Gruntfuggly.todo-tree` - TODO comment tree view
  - `yzhang.markdown-all-in-one` - Markdown editing support
  - `mushan.vscode-paste-image` - Paste images into markdown
  - `tonybaloney.vscode-pets` - Virtual pets

## Test Plan
- [ ] Rebuild devcontainer and verify extensions install correctly

Generated with Claude Code