### PR TITLE
feat: add furniture checklist data layer

### DIFF
--- a/src/lib/__tests__/furniture-checklist.test.ts
+++ b/src/lib/__tests__/furniture-checklist.test.ts
@@ -1,0 +1,238 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  createChecklist,
+  getChecklist,
+  updateChecklistItem,
+  getChecklistSummary,
+  getAgreedFurnitureIds,
+  confirmChecklist,
+  resetChecklistState,
+} from '../furniture-checklist';
+import type { FurnitureItem } from '../data';
+
+describe('furniture checklist', () => {
+  beforeEach(() => {
+    resetChecklistState();
+  });
+
+  const sampleFurniture: FurnitureItem[] = [
+    { type: 'bed', photos: ['/bed.jpg'], condition: 'excellent' },
+    { type: 'sofa', photos: ['/sofa.jpg'], condition: 'good' },
+    { type: 'desk', photos: [], condition: 'fair', notes: '少し傷あり' },
+  ];
+
+  describe('createChecklist', () => {
+    it('creates a checklist from furniture items for a listing', () => {
+      const checklist = createChecklist(
+        'listing-1',
+        'thread-1',
+        sampleFurniture
+      );
+      expect(checklist.id).toBeTruthy();
+      expect(checklist.listingId).toBe('listing-1');
+      expect(checklist.threadId).toBe('thread-1');
+      expect(checklist.status).toBe('draft');
+      expect(checklist.items).toHaveLength(3);
+    });
+
+    it('initializes all items with undecided disposition', () => {
+      const checklist = createChecklist(
+        'listing-1',
+        'thread-1',
+        sampleFurniture
+      );
+      for (const item of checklist.items) {
+        expect(item.disposition).toBe('undecided');
+      }
+    });
+
+    it('preserves furniture type, photos, and condition in checklist items', () => {
+      const checklist = createChecklist(
+        'listing-1',
+        'thread-1',
+        sampleFurniture
+      );
+      expect(checklist.items[0].furnitureType).toBe('bed');
+      expect(checklist.items[0].photos).toEqual(['/bed.jpg']);
+      expect(checklist.items[0].condition).toBe('excellent');
+      expect(checklist.items[2].notes).toBe('少し傷あり');
+    });
+
+    it('returns existing checklist if same listing+thread combo exists', () => {
+      const c1 = createChecklist('listing-1', 'thread-1', sampleFurniture);
+      const c2 = createChecklist('listing-1', 'thread-1', sampleFurniture);
+      expect(c1.id).toBe(c2.id);
+    });
+  });
+
+  describe('getChecklist', () => {
+    it('retrieves a checklist by id', () => {
+      const created = createChecklist('listing-1', 'thread-1', sampleFurniture);
+      const fetched = getChecklist(created.id);
+      expect(fetched).toBeDefined();
+      expect(fetched!.id).toBe(created.id);
+    });
+
+    it('returns undefined for nonexistent checklist', () => {
+      expect(getChecklist('nonexistent')).toBeUndefined();
+    });
+  });
+
+  describe('updateChecklistItem', () => {
+    it('updates item disposition to keep', () => {
+      const checklist = createChecklist(
+        'listing-1',
+        'thread-1',
+        sampleFurniture
+      );
+      const itemId = checklist.items[0].id;
+      const updated = updateChecklistItem(checklist.id, itemId, 'keep');
+      const item = updated.items.find((i) => i.id === itemId);
+      expect(item!.disposition).toBe('keep');
+    });
+
+    it('updates item disposition to take_away', () => {
+      const checklist = createChecklist(
+        'listing-1',
+        'thread-1',
+        sampleFurniture
+      );
+      const itemId = checklist.items[1].id;
+      const updated = updateChecklistItem(checklist.id, itemId, 'take_away');
+      const item = updated.items.find((i) => i.id === itemId);
+      expect(item!.disposition).toBe('take_away');
+    });
+
+    it('throws for nonexistent checklist', () => {
+      expect(() => updateChecklistItem('bad-id', 'item-1', 'keep')).toThrow(
+        'チェックリストが見つかりません'
+      );
+    });
+
+    it('throws for nonexistent item', () => {
+      const checklist = createChecklist(
+        'listing-1',
+        'thread-1',
+        sampleFurniture
+      );
+      expect(() =>
+        updateChecklistItem(checklist.id, 'bad-item', 'keep')
+      ).toThrow('チェックリストアイテムが見つかりません');
+    });
+
+    it('does not mutate the original checklist', () => {
+      const checklist = createChecklist(
+        'listing-1',
+        'thread-1',
+        sampleFurniture
+      );
+      const itemId = checklist.items[0].id;
+      const updated = updateChecklistItem(checklist.id, itemId, 'keep');
+      expect(updated).not.toBe(checklist);
+      expect(updated.items).not.toBe(checklist.items);
+    });
+
+    it('rejects updates on confirmed checklists', () => {
+      const checklist = createChecklist(
+        'listing-1',
+        'thread-1',
+        sampleFurniture
+      );
+      const itemId = checklist.items[0].id;
+      updateChecklistItem(checklist.id, itemId, 'keep');
+      updateChecklistItem(checklist.id, checklist.items[1].id, 'take_away');
+      updateChecklistItem(checklist.id, checklist.items[2].id, 'keep');
+      confirmChecklist(checklist.id);
+
+      expect(() =>
+        updateChecklistItem(checklist.id, itemId, 'take_away')
+      ).toThrow('確定済みのチェックリストは変更できません');
+    });
+  });
+
+  describe('getChecklistSummary', () => {
+    it('returns correct counts for each disposition', () => {
+      const checklist = createChecklist(
+        'listing-1',
+        'thread-1',
+        sampleFurniture
+      );
+      updateChecklistItem(checklist.id, checklist.items[0].id, 'keep');
+      updateChecklistItem(checklist.id, checklist.items[1].id, 'take_away');
+
+      const summary = getChecklistSummary(checklist.id);
+      expect(summary.keep).toBe(1);
+      expect(summary.takeAway).toBe(1);
+      expect(summary.undecided).toBe(1);
+      expect(summary.total).toBe(3);
+    });
+
+    it('throws for nonexistent checklist', () => {
+      expect(() => getChecklistSummary('bad-id')).toThrow(
+        'チェックリストが見つかりません'
+      );
+    });
+  });
+
+  describe('getAgreedFurnitureIds', () => {
+    it('returns furniture types marked as keep', () => {
+      const checklist = createChecklist(
+        'listing-1',
+        'thread-1',
+        sampleFurniture
+      );
+      updateChecklistItem(checklist.id, checklist.items[0].id, 'keep');
+      updateChecklistItem(checklist.id, checklist.items[1].id, 'take_away');
+      updateChecklistItem(checklist.id, checklist.items[2].id, 'keep');
+
+      const agreed = getAgreedFurnitureIds(checklist.id);
+      expect(agreed).toEqual(['bed', 'desk']);
+    });
+  });
+
+  describe('confirmChecklist', () => {
+    it('confirms a checklist when all items are decided', () => {
+      const checklist = createChecklist(
+        'listing-1',
+        'thread-1',
+        sampleFurniture
+      );
+      updateChecklistItem(checklist.id, checklist.items[0].id, 'keep');
+      updateChecklistItem(checklist.id, checklist.items[1].id, 'take_away');
+      updateChecklistItem(checklist.id, checklist.items[2].id, 'keep');
+
+      const confirmed = confirmChecklist(checklist.id);
+      expect(confirmed.status).toBe('confirmed');
+      expect(confirmed.confirmedAt).toBeTruthy();
+    });
+
+    it('rejects confirmation when items are still undecided', () => {
+      const checklist = createChecklist(
+        'listing-1',
+        'thread-1',
+        sampleFurniture
+      );
+      updateChecklistItem(checklist.id, checklist.items[0].id, 'keep');
+
+      expect(() => confirmChecklist(checklist.id)).toThrow(
+        '未決定のアイテムがあります'
+      );
+    });
+
+    it('rejects confirming an already confirmed checklist', () => {
+      const checklist = createChecklist(
+        'listing-1',
+        'thread-1',
+        sampleFurniture
+      );
+      updateChecklistItem(checklist.id, checklist.items[0].id, 'keep');
+      updateChecklistItem(checklist.id, checklist.items[1].id, 'keep');
+      updateChecklistItem(checklist.id, checklist.items[2].id, 'take_away');
+      confirmChecklist(checklist.id);
+
+      expect(() => confirmChecklist(checklist.id)).toThrow(
+        'このチェックリストは既に確定済みです'
+      );
+    });
+  });
+});

--- a/src/lib/furniture-checklist.ts
+++ b/src/lib/furniture-checklist.ts
@@ -1,0 +1,200 @@
+/**
+ * 残置物チェックリスト機能
+ *
+ * 前の住人が出品時に登録した家具リストをベースに、
+ * 内見時に「引き継ぐ/引き継がない/検討中」をチェック。
+ * 確定後、agreedFurnitureIdsが決まり残置物同意書の根拠となる。
+ */
+
+import type { FurnitureItem, LargeFurnitureType } from './data';
+
+export type ItemDisposition = 'keep' | 'take_away' | 'undecided';
+
+export interface ChecklistItem {
+  id: string;
+  furnitureType: LargeFurnitureType;
+  photos: string[];
+  condition?: 'excellent' | 'good' | 'fair';
+  notes?: string;
+  disposition: ItemDisposition;
+}
+
+export type ChecklistStatus = 'draft' | 'confirmed';
+
+export interface FurnitureChecklist {
+  id: string;
+  listingId: string;
+  threadId: string;
+  status: ChecklistStatus;
+  items: ChecklistItem[];
+  createdAt: string;
+  confirmedAt?: string;
+}
+
+export interface ChecklistSummary {
+  keep: number;
+  takeAway: number;
+  undecided: number;
+  total: number;
+}
+
+// In-memory store (mock, will be replaced with DB)
+let checklists: FurnitureChecklist[] = [];
+let nextId = 1;
+
+function generateId(): string {
+  return `cl-${nextId++}-${Date.now()}`;
+}
+
+/**
+ * Creates a checklist from furniture items. Returns existing if same listing+thread exists.
+ */
+export function createChecklist(
+  listingId: string,
+  threadId: string,
+  furnitureItems: FurnitureItem[]
+): FurnitureChecklist {
+  const existing = checklists.find(
+    (c) => c.listingId === listingId && c.threadId === threadId
+  );
+  if (existing) return existing;
+
+  const items: ChecklistItem[] = furnitureItems.map((f) => ({
+    id: generateId(),
+    furnitureType: f.type,
+    photos: [...f.photos],
+    condition: f.condition,
+    notes: f.notes,
+    disposition: 'undecided' as const,
+  }));
+
+  const checklist: FurnitureChecklist = {
+    id: generateId(),
+    listingId,
+    threadId,
+    status: 'draft',
+    items,
+    createdAt: new Date().toISOString(),
+  };
+
+  checklists = [...checklists, checklist];
+  return checklist;
+}
+
+/**
+ * Retrieves a checklist by ID.
+ */
+export function getChecklist(
+  checklistId: string
+): FurnitureChecklist | undefined {
+  return checklists.find((c) => c.id === checklistId);
+}
+
+/**
+ * Updates an item's disposition. Throws if checklist is confirmed.
+ */
+export function updateChecklistItem(
+  checklistId: string,
+  itemId: string,
+  disposition: ItemDisposition
+): FurnitureChecklist {
+  const checklist = checklists.find((c) => c.id === checklistId);
+  if (!checklist) {
+    throw new Error('チェックリストが見つかりません');
+  }
+
+  if (checklist.status === 'confirmed') {
+    throw new Error('確定済みのチェックリストは変更できません');
+  }
+
+  const itemIndex = checklist.items.findIndex((i) => i.id === itemId);
+  if (itemIndex === -1) {
+    throw new Error('チェックリストアイテムが見つかりません');
+  }
+
+  const updatedItems = checklist.items.map((item) =>
+    item.id === itemId ? { ...item, disposition } : item
+  );
+
+  const updated: FurnitureChecklist = {
+    ...checklist,
+    items: updatedItems,
+  };
+
+  checklists = checklists.map((c) => (c.id === checklistId ? updated : c));
+  return updated;
+}
+
+/**
+ * Returns a summary of item dispositions.
+ */
+export function getChecklistSummary(checklistId: string): ChecklistSummary {
+  const checklist = checklists.find((c) => c.id === checklistId);
+  if (!checklist) {
+    throw new Error('チェックリストが見つかりません');
+  }
+
+  const keep = checklist.items.filter((i) => i.disposition === 'keep').length;
+  const takeAway = checklist.items.filter(
+    (i) => i.disposition === 'take_away'
+  ).length;
+  const undecided = checklist.items.filter(
+    (i) => i.disposition === 'undecided'
+  ).length;
+
+  return { keep, takeAway, undecided, total: checklist.items.length };
+}
+
+/**
+ * Returns the furniture types marked as "keep" (agreed to take over).
+ */
+export function getAgreedFurnitureIds(
+  checklistId: string
+): LargeFurnitureType[] {
+  const checklist = checklists.find((c) => c.id === checklistId);
+  if (!checklist) {
+    throw new Error('チェックリストが見つかりません');
+  }
+
+  return checklist.items
+    .filter((i) => i.disposition === 'keep')
+    .map((i) => i.furnitureType);
+}
+
+/**
+ * Confirms a checklist. All items must be decided (no undecided).
+ */
+export function confirmChecklist(checklistId: string): FurnitureChecklist {
+  const checklist = checklists.find((c) => c.id === checklistId);
+  if (!checklist) {
+    throw new Error('チェックリストが見つかりません');
+  }
+
+  if (checklist.status === 'confirmed') {
+    throw new Error('このチェックリストは既に確定済みです');
+  }
+
+  const hasUndecided = checklist.items.some(
+    (i) => i.disposition === 'undecided'
+  );
+  if (hasUndecided) {
+    throw new Error('未決定のアイテムがあります');
+  }
+
+  const confirmed: FurnitureChecklist = {
+    ...checklist,
+    status: 'confirmed',
+    confirmedAt: new Date().toISOString(),
+  };
+
+  checklists = checklists.map((c) => (c.id === checklistId ? confirmed : c));
+  return confirmed;
+}
+
+/**
+ * Resets all in-memory state. Used for testing.
+ */
+export function resetChecklistState(): void {
+  checklists = [];
+  nextId = 1;
+}


### PR DESCRIPTION
## Summary

- Implement furniture checklist module for viewing handover decisions (F-613)
- ChecklistItem type with disposition tracking: keep (引き継ぐ) / take_away (持っていく) / undecided (検討中)
- Creates checklist from listing's existing FurnitureItem data (photos, condition preserved)
- Deduplication: one checklist per listing+thread combination
- Confirmation flow: all items must be decided before checklist can be confirmed
- Immutable patterns throughout (no mutation)
- Utility functions: summary stats, agreed furniture extraction (agreedFurnitureIds)
- In-memory store (mock, to be replaced with DB)

## Test plan

- [x] 18 unit tests covering all checklist functions
- [x] Checklist creation and deduplication
- [x] Item disposition updates (keep, take_away, undecided)
- [x] Rejection of updates on confirmed checklists
- [x] Summary statistics (keep/takeAway/undecided counts)
- [x] Agreed furniture ID extraction
- [x] Confirmation validation (no undecided items, no double-confirm)
- [x] Immutability verification
- [x] All 282 tests pass (264 existing + 18 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)