### PR TITLE
feat: add viewing flow orchestration module

### DIFF
--- a/src/lib/__tests__/viewing-flow.test.ts
+++ b/src/lib/__tests__/viewing-flow.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  createViewing,
+  getViewing,
+  getViewingsByListing,
+  scheduleViewing,
+  completeViewing,
+  submitBuyerChecklist,
+  approveChecklist,
+  getViewingStatus,
+  resetViewingState,
+} from '../viewing-flow';
+import { resetMessagingState } from '../messaging';
+import { resetChecklistState } from '../furniture-checklist';
+import type { FurnitureItem } from '../data';
+
+describe('viewing flow', () => {
+  beforeEach(() => {
+    resetViewingState();
+    resetMessagingState();
+    resetChecklistState();
+  });
+
+  const sampleFurniture: FurnitureItem[] = [
+    { type: 'bed', photos: ['/bed.jpg'], condition: 'excellent' },
+    { type: 'sofa', photos: ['/sofa.jpg'], condition: 'good' },
+  ];
+
+  describe('createViewing', () => {
+    it('creates a viewing request for a listing', () => {
+      const viewing = createViewing(
+        'listing-1',
+        'seller-1',
+        'buyer-1',
+        sampleFurniture
+      );
+      expect(viewing.id).toBeTruthy();
+      expect(viewing.listingId).toBe('listing-1');
+      expect(viewing.sellerId).toBe('seller-1');
+      expect(viewing.buyerId).toBe('buyer-1');
+      expect(viewing.status).toBe('requested');
+      expect(viewing.threadId).toBeTruthy();
+      expect(viewing.checklistId).toBeTruthy();
+    });
+
+    it('creates messaging thread and checklist automatically', () => {
+      const viewing = createViewing(
+        'listing-1',
+        'seller-1',
+        'buyer-1',
+        sampleFurniture
+      );
+      expect(viewing.threadId).toBeTruthy();
+      expect(viewing.checklistId).toBeTruthy();
+    });
+
+    it('returns existing viewing for same listing+buyer combo', () => {
+      const v1 = createViewing(
+        'listing-1',
+        'seller-1',
+        'buyer-1',
+        sampleFurniture
+      );
+      const v2 = createViewing(
+        'listing-1',
+        'seller-1',
+        'buyer-1',
+        sampleFurniture
+      );
+      expect(v1.id).toBe(v2.id);
+    });
+  });
+
+  describe('getViewing', () => {
+    it('retrieves a viewing by id', () => {
+      const created = createViewing(
+        'listing-1',
+        'seller-1',
+        'buyer-1',
+        sampleFurniture
+      );
+      const fetched = getViewing(created.id);
+      expect(fetched).toBeDefined();
+      expect(fetched!.id).toBe(created.id);
+    });
+
+    it('returns undefined for nonexistent viewing', () => {
+      expect(getViewing('nonexistent')).toBeUndefined();
+    });
+  });
+
+  describe('getViewingsByListing', () => {
+    it('returns all viewings for a listing', () => {
+      createViewing('listing-1', 'seller-1', 'buyer-1', sampleFurniture);
+      createViewing('listing-1', 'seller-1', 'buyer-2', sampleFurniture);
+      createViewing('listing-2', 'seller-2', 'buyer-3', sampleFurniture);
+
+      const viewings = getViewingsByListing('listing-1');
+      expect(viewings).toHaveLength(2);
+    });
+  });
+
+  describe('scheduleViewing', () => {
+    it('updates viewing status to scheduled with date', () => {
+      const viewing = createViewing(
+        'listing-1',
+        'seller-1',
+        'buyer-1',
+        sampleFurniture
+      );
+      const scheduled = scheduleViewing(viewing.id, '2026-02-20T14:00:00');
+      expect(scheduled.status).toBe('scheduled');
+      expect(scheduled.scheduledDate).toBe('2026-02-20T14:00:00');
+    });
+
+    it('throws for nonexistent viewing', () => {
+      expect(() => scheduleViewing('bad-id', '2026-02-20T14:00:00')).toThrow(
+        '内見が見つかりません'
+      );
+    });
+  });
+
+  describe('completeViewing', () => {
+    it('marks viewing as completed', () => {
+      const viewing = createViewing(
+        'listing-1',
+        'seller-1',
+        'buyer-1',
+        sampleFurniture
+      );
+      scheduleViewing(viewing.id, '2026-02-20T14:00:00');
+      const completed = completeViewing(viewing.id);
+      expect(completed.status).toBe('completed');
+      expect(completed.completedAt).toBeTruthy();
+    });
+
+    it('throws if viewing is not scheduled', () => {
+      const viewing = createViewing(
+        'listing-1',
+        'seller-1',
+        'buyer-1',
+        sampleFurniture
+      );
+      expect(() => completeViewing(viewing.id)).toThrow(
+        '内見がスケジュール済みではありません'
+      );
+    });
+  });
+
+  describe('submitBuyerChecklist', () => {
+    it('marks viewing as checklist_submitted', () => {
+      const viewing = createViewing(
+        'listing-1',
+        'seller-1',
+        'buyer-1',
+        sampleFurniture
+      );
+      scheduleViewing(viewing.id, '2026-02-20T14:00:00');
+      completeViewing(viewing.id);
+
+      const submitted = submitBuyerChecklist(viewing.id);
+      expect(submitted.status).toBe('checklist_submitted');
+    });
+
+    it('throws if viewing is not completed', () => {
+      const viewing = createViewing(
+        'listing-1',
+        'seller-1',
+        'buyer-1',
+        sampleFurniture
+      );
+      expect(() => submitBuyerChecklist(viewing.id)).toThrow(
+        '内見が完了していません'
+      );
+    });
+  });
+
+  describe('approveChecklist', () => {
+    it('marks viewing as agreed and returns agreed furniture ids', () => {
+      const viewing = createViewing(
+        'listing-1',
+        'seller-1',
+        'buyer-1',
+        sampleFurniture
+      );
+      scheduleViewing(viewing.id, '2026-02-20T14:00:00');
+      completeViewing(viewing.id);
+      submitBuyerChecklist(viewing.id);
+
+      const approved = approveChecklist(viewing.id);
+      expect(approved.status).toBe('agreed');
+      expect(approved.agreedAt).toBeTruthy();
+    });
+
+    it('throws if checklist not submitted', () => {
+      const viewing = createViewing(
+        'listing-1',
+        'seller-1',
+        'buyer-1',
+        sampleFurniture
+      );
+      scheduleViewing(viewing.id, '2026-02-20T14:00:00');
+      completeViewing(viewing.id);
+
+      expect(() => approveChecklist(viewing.id)).toThrow(
+        'チェックリストが提出されていません'
+      );
+    });
+  });
+
+  describe('getViewingStatus', () => {
+    it('returns human-readable status info', () => {
+      const viewing = createViewing(
+        'listing-1',
+        'seller-1',
+        'buyer-1',
+        sampleFurniture
+      );
+      const status = getViewingStatus(viewing.id);
+      expect(status.label).toBe('リクエスト中');
+      expect(status.step).toBe(1);
+      expect(status.totalSteps).toBe(5);
+    });
+
+    it('progresses through steps correctly', () => {
+      const viewing = createViewing(
+        'listing-1',
+        'seller-1',
+        'buyer-1',
+        sampleFurniture
+      );
+
+      scheduleViewing(viewing.id, '2026-02-20T14:00:00');
+      expect(getViewingStatus(viewing.id).step).toBe(2);
+
+      completeViewing(viewing.id);
+      expect(getViewingStatus(viewing.id).step).toBe(3);
+
+      submitBuyerChecklist(viewing.id);
+      expect(getViewingStatus(viewing.id).step).toBe(4);
+
+      approveChecklist(viewing.id);
+      expect(getViewingStatus(viewing.id).step).toBe(5);
+    });
+  });
+});

--- a/src/lib/viewing-flow.ts
+++ b/src/lib/viewing-flow.ts
@@ -1,0 +1,228 @@
+/**
+ * 内見フロー管理
+ *
+ * 内見の全ライフサイクルを管理:
+ * 1. リクエスト → 2. スケジュール確定 → 3. 内見完了
+ * → 4. チェックリスト提出 → 5. 合意確定（agreedFurnitureIds）
+ *
+ * メッセージングとチェックリストモジュールを統合し、
+ * 内見フローの状態遷移を一元管理する。
+ */
+
+import type { FurnitureItem, LargeFurnitureType } from './data';
+import { createThread } from './messaging';
+import { createChecklist, getAgreedFurnitureIds } from './furniture-checklist';
+
+export type ViewingStatus =
+  | 'requested'
+  | 'scheduled'
+  | 'completed'
+  | 'checklist_submitted'
+  | 'agreed';
+
+export interface Viewing {
+  id: string;
+  listingId: string;
+  sellerId: string;
+  buyerId: string;
+  threadId: string;
+  checklistId: string;
+  status: ViewingStatus;
+  scheduledDate?: string;
+  completedAt?: string;
+  agreedFurnitureIds?: LargeFurnitureType[];
+  agreedAt?: string;
+  createdAt: string;
+}
+
+export interface ViewingStatusInfo {
+  label: string;
+  step: number;
+  totalSteps: number;
+}
+
+const STATUS_INFO: Record<ViewingStatus, { label: string; step: number }> = {
+  requested: { label: 'リクエスト中', step: 1 },
+  scheduled: { label: '日程確定', step: 2 },
+  completed: { label: '内見完了', step: 3 },
+  checklist_submitted: { label: 'チェックリスト提出済み', step: 4 },
+  agreed: { label: '合意済み', step: 5 },
+};
+
+const TOTAL_STEPS = 5;
+
+// In-memory store (mock, will be replaced with DB)
+let viewings: Viewing[] = [];
+let nextId = 1;
+
+function generateId(): string {
+  return `vw-${nextId++}-${Date.now()}`;
+}
+
+/**
+ * Creates a viewing request. Also creates a messaging thread and checklist.
+ * Returns existing viewing if same listing+buyer combo exists.
+ */
+export function createViewing(
+  listingId: string,
+  sellerId: string,
+  buyerId: string,
+  furnitureItems: FurnitureItem[]
+): Viewing {
+  const existing = viewings.find(
+    (v) => v.listingId === listingId && v.buyerId === buyerId
+  );
+  if (existing) return existing;
+
+  // Create messaging thread for this viewing
+  const thread = createThread(listingId, sellerId, buyerId);
+
+  // Create furniture checklist from listing's items
+  const checklist = createChecklist(listingId, thread.id, furnitureItems);
+
+  const viewing: Viewing = {
+    id: generateId(),
+    listingId,
+    sellerId,
+    buyerId,
+    threadId: thread.id,
+    checklistId: checklist.id,
+    status: 'requested',
+    createdAt: new Date().toISOString(),
+  };
+
+  viewings = [...viewings, viewing];
+  return viewing;
+}
+
+/**
+ * Retrieves a viewing by ID.
+ */
+export function getViewing(viewingId: string): Viewing | undefined {
+  return viewings.find((v) => v.id === viewingId);
+}
+
+/**
+ * Returns all viewings for a listing.
+ */
+export function getViewingsByListing(listingId: string): Viewing[] {
+  return viewings.filter((v) => v.listingId === listingId);
+}
+
+/**
+ * Schedules a viewing with a confirmed date.
+ */
+export function scheduleViewing(
+  viewingId: string,
+  scheduledDate: string
+): Viewing {
+  const viewing = viewings.find((v) => v.id === viewingId);
+  if (!viewing) {
+    throw new Error('内見が見つかりません');
+  }
+
+  const updated: Viewing = {
+    ...viewing,
+    status: 'scheduled',
+    scheduledDate,
+  };
+
+  viewings = viewings.map((v) => (v.id === viewingId ? updated : v));
+  return updated;
+}
+
+/**
+ * Marks a viewing as completed (after the physical visit).
+ */
+export function completeViewing(viewingId: string): Viewing {
+  const viewing = viewings.find((v) => v.id === viewingId);
+  if (!viewing) {
+    throw new Error('内見が見つかりません');
+  }
+
+  if (viewing.status !== 'scheduled') {
+    throw new Error('内見がスケジュール済みではありません');
+  }
+
+  const updated: Viewing = {
+    ...viewing,
+    status: 'completed',
+    completedAt: new Date().toISOString(),
+  };
+
+  viewings = viewings.map((v) => (v.id === viewingId ? updated : v));
+  return updated;
+}
+
+/**
+ * Buyer submits their checklist selections.
+ */
+export function submitBuyerChecklist(viewingId: string): Viewing {
+  const viewing = viewings.find((v) => v.id === viewingId);
+  if (!viewing) {
+    throw new Error('内見が見つかりません');
+  }
+
+  if (viewing.status !== 'completed') {
+    throw new Error('内見が完了していません');
+  }
+
+  const updated: Viewing = {
+    ...viewing,
+    status: 'checklist_submitted',
+  };
+
+  viewings = viewings.map((v) => (v.id === viewingId ? updated : v));
+  return updated;
+}
+
+/**
+ * Seller approves the checklist, finalizing agreedFurnitureIds.
+ */
+export function approveChecklist(viewingId: string): Viewing {
+  const viewing = viewings.find((v) => v.id === viewingId);
+  if (!viewing) {
+    throw new Error('内見が見つかりません');
+  }
+
+  if (viewing.status !== 'checklist_submitted') {
+    throw new Error('チェックリストが提出されていません');
+  }
+
+  const agreedIds = getAgreedFurnitureIds(viewing.checklistId);
+
+  const updated: Viewing = {
+    ...viewing,
+    status: 'agreed',
+    agreedFurnitureIds: agreedIds,
+    agreedAt: new Date().toISOString(),
+  };
+
+  viewings = viewings.map((v) => (v.id === viewingId ? updated : v));
+  return updated;
+}
+
+/**
+ * Returns human-readable status info for a viewing.
+ */
+export function getViewingStatus(viewingId: string): ViewingStatusInfo {
+  const viewing = viewings.find((v) => v.id === viewingId);
+  if (!viewing) {
+    throw new Error('内見が見つかりません');
+  }
+
+  const info = STATUS_INFO[viewing.status];
+  return {
+    label: info.label,
+    step: info.step,
+    totalSteps: TOTAL_STEPS,
+  };
+}
+
+/**
+ * Resets all in-memory state. Used for testing.
+ */
+export function resetViewingState(): void {
+  viewings = [];
+  nextId = 1;
+}


### PR DESCRIPTION
## Summary

- Implement viewing lifecycle management connecting messaging and furniture checklist modules
- 5-step state machine: requested → scheduled → completed → checklist_submitted → agreed
- Automatically creates messaging thread and furniture checklist on viewing creation
- Deduplication: one viewing per listing + buyer combination
- Status transitions with validation (must follow correct sequence)
- Extracts agreedFurnitureIds from checklist on seller approval
- Human-readable status info with step progress (1/5 through 5/5)
- Immutable patterns throughout
- In-memory store (mock, to be replaced with DB)

## Test plan

- [x] 16 unit tests covering full viewing lifecycle
- [x] Viewing creation with auto thread/checklist creation
- [x] Deduplication of same listing+buyer viewings
- [x] Status transitions: schedule, complete, submit, approve
- [x] Validation: cannot skip steps (e.g., complete before schedule)
- [x] Status info returns correct labels and step counts
- [x] All 298 tests pass (282 existing + 16 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)