### PR TITLE
chore: remove vscode-pets from devcontainer extensions

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,8 +22,7 @@
         "GitHub.vscode-pull-request-github",
         "Gruntfuggly.todo-tree",
         "yzhang.markdown-all-in-one",
-        "mushan.vscode-paste-image",
-        "tonybaloney.vscode-pets"
+        "mushan.vscode-paste-image"
       ],
       "settings": {
         "editor.formatOnSave": true,


### PR DESCRIPTION
## Summary
- Remove `tonybaloney.vscode-pets` from shared devcontainer extensions
- Personal/entertainment extension should be installed via user-level `dev.containers.defaultExtensions` setting

## Changes
- `.devcontainer/devcontainer.json`: Removed `tonybaloney.vscode-pets` from extensions list

## Test Plan
- [ ] Devcontainer builds successfully without the extension
- [ ] Other extensions still install correctly

Generated with Claude Code