### PR TITLE
feat: add handover agreement data module

### DIFF
--- a/src/lib/__tests__/handover-agreement.test.ts
+++ b/src/lib/__tests__/handover-agreement.test.ts
@@ -1,0 +1,286 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  createAgreementFromViewing,
+  getAgreement,
+  getAgreementByViewing,
+  acceptAgreement,
+  signAgreement,
+  resetAgreementState,
+} from '../handover-agreement';
+import {
+  createViewing,
+  scheduleViewing,
+  completeViewing,
+  submitBuyerChecklist,
+  approveChecklist,
+  resetViewingState,
+} from '../viewing-flow';
+import {
+  updateChecklistItem,
+  confirmChecklist,
+  getChecklist,
+  resetChecklistState,
+} from '../furniture-checklist';
+import { resetMessagingState } from '../messaging';
+import type { FurnitureItem } from '../data';
+
+const FURNITURE_ITEMS: FurnitureItem[] = [
+  {
+    type: 'bed',
+    photos: ['/bed.jpg'],
+    condition: 'excellent',
+    notes: 'シングルベッド',
+  },
+  { type: 'desk', photos: ['/desk.jpg'], condition: 'good' },
+  { type: 'sofa', photos: ['/sofa.jpg'], condition: 'fair', notes: '3人掛け' },
+];
+
+function createAgreedViewing() {
+  const viewing = createViewing(
+    'listing-1',
+    'seller-1',
+    'buyer-1',
+    FURNITURE_ITEMS
+  );
+  scheduleViewing(viewing.id, '2026-02-15T10:00:00');
+  completeViewing(viewing.id);
+
+  // Buyer decides: keep bed, take_away desk, keep sofa
+  const checklist = getChecklist(viewing.checklistId)!;
+  updateChecklistItem(checklist.id, checklist.items[0].id, 'keep');
+  updateChecklistItem(checklist.id, checklist.items[1].id, 'take_away');
+  updateChecklistItem(checklist.id, checklist.items[2].id, 'keep');
+  confirmChecklist(checklist.id);
+
+  submitBuyerChecklist(viewing.id);
+  approveChecklist(viewing.id);
+  return viewing;
+}
+
+describe('handover-agreement', () => {
+  beforeEach(() => {
+    resetAgreementState();
+    resetViewingState();
+    resetChecklistState();
+    resetMessagingState();
+  });
+
+  describe('createAgreementFromViewing', () => {
+    it('creates an agreement from an agreed viewing', () => {
+      const viewing = createAgreedViewing();
+      const agreement = createAgreementFromViewing(viewing.id, {
+        sellerName: '田中太郎',
+        sellerEmail: 'tanaka@example.com',
+        buyerName: '山田花子',
+        buyerEmail: 'yamada@example.com',
+        propertyTitle: '世田谷の家具付き物件',
+        propertyAddress: '世田谷区1-2-3',
+        handoverFee: 50000,
+      });
+
+      expect(agreement.id).toBeTruthy();
+      expect(agreement.viewingId).toBe(viewing.id);
+      expect(agreement.status).toBe('draft');
+      expect(agreement.sellerName).toBe('田中太郎');
+      expect(agreement.buyerName).toBe('山田花子');
+      expect(agreement.handoverFee).toBe(50000);
+      expect(agreement.items).toHaveLength(2); // only 'keep' items (bed, sofa)
+      expect(agreement.items.map((i) => i.furnitureType)).toEqual([
+        'bed',
+        'sofa',
+      ]);
+    });
+
+    it('rejects creating agreement for non-agreed viewing', () => {
+      const viewing = createViewing(
+        'listing-1',
+        'seller-1',
+        'buyer-1',
+        FURNITURE_ITEMS
+      );
+      expect(() =>
+        createAgreementFromViewing(viewing.id, {
+          sellerName: '田中',
+          sellerEmail: 'a@b.com',
+          buyerName: '山田',
+          buyerEmail: 'c@d.com',
+          propertyTitle: 'テスト',
+          handoverFee: 10000,
+        })
+      ).toThrow('合意済みの内見のみ');
+    });
+
+    it('returns existing agreement if already created for viewing', () => {
+      const viewing = createAgreedViewing();
+      const params = {
+        sellerName: '田中',
+        sellerEmail: 'a@b.com',
+        buyerName: '山田',
+        buyerEmail: 'c@d.com',
+        propertyTitle: 'テスト',
+        handoverFee: 10000,
+      };
+      const a1 = createAgreementFromViewing(viewing.id, params);
+      const a2 = createAgreementFromViewing(viewing.id, params);
+      expect(a1.id).toBe(a2.id);
+    });
+  });
+
+  describe('getAgreement', () => {
+    it('returns agreement by ID', () => {
+      const viewing = createAgreedViewing();
+      const agreement = createAgreementFromViewing(viewing.id, {
+        sellerName: '田中',
+        sellerEmail: 'a@b.com',
+        buyerName: '山田',
+        buyerEmail: 'c@d.com',
+        propertyTitle: 'テスト',
+        handoverFee: 10000,
+      });
+
+      expect(getAgreement(agreement.id)).toBeDefined();
+      expect(getAgreement(agreement.id)!.id).toBe(agreement.id);
+    });
+
+    it('returns undefined for unknown ID', () => {
+      expect(getAgreement('nonexistent')).toBeUndefined();
+    });
+  });
+
+  describe('getAgreementByViewing', () => {
+    it('returns agreement for a viewing', () => {
+      const viewing = createAgreedViewing();
+      const agreement = createAgreementFromViewing(viewing.id, {
+        sellerName: '田中',
+        sellerEmail: 'a@b.com',
+        buyerName: '山田',
+        buyerEmail: 'c@d.com',
+        propertyTitle: 'テスト',
+        handoverFee: 10000,
+      });
+
+      expect(getAgreementByViewing(viewing.id)).toBeDefined();
+      expect(getAgreementByViewing(viewing.id)!.id).toBe(agreement.id);
+    });
+  });
+
+  describe('acceptAgreement', () => {
+    it('transitions from draft to pending_acceptance', () => {
+      const viewing = createAgreedViewing();
+      const agreement = createAgreementFromViewing(viewing.id, {
+        sellerName: '田中',
+        sellerEmail: 'a@b.com',
+        buyerName: '山田',
+        buyerEmail: 'c@d.com',
+        propertyTitle: 'テスト',
+        handoverFee: 10000,
+      });
+
+      const accepted = acceptAgreement(agreement.id);
+      expect(accepted.status).toBe('pending_acceptance');
+      expect(accepted.acceptedAt).toBeTruthy();
+    });
+
+    it('rejects accepting non-draft agreement', () => {
+      const viewing = createAgreedViewing();
+      const agreement = createAgreementFromViewing(viewing.id, {
+        sellerName: '田中',
+        sellerEmail: 'a@b.com',
+        buyerName: '山田',
+        buyerEmail: 'c@d.com',
+        propertyTitle: 'テスト',
+        handoverFee: 10000,
+      });
+      acceptAgreement(agreement.id);
+      expect(() => acceptAgreement(agreement.id)).toThrow(
+        'ドラフト状態の合意のみ'
+      );
+    });
+  });
+
+  describe('signAgreement', () => {
+    it('transitions from pending_acceptance to signed', () => {
+      const viewing = createAgreedViewing();
+      const agreement = createAgreementFromViewing(viewing.id, {
+        sellerName: '田中',
+        sellerEmail: 'a@b.com',
+        buyerName: '山田',
+        buyerEmail: 'c@d.com',
+        propertyTitle: 'テスト',
+        handoverFee: 10000,
+      });
+      acceptAgreement(agreement.id);
+
+      const signed = signAgreement(agreement.id, {
+        name: '山田花子',
+        ipAddress: '192.168.1.1',
+      });
+
+      expect(signed.status).toBe('signed');
+      expect(signed.signedAt).toBeTruthy();
+      expect(signed.buyerSignature).toBeDefined();
+      expect(signed.buyerSignature!.name).toBe('山田花子');
+      expect(signed.buyerSignature!.ipAddress).toBe('192.168.1.1');
+    });
+
+    it('rejects signing non-accepted agreement', () => {
+      const viewing = createAgreedViewing();
+      const agreement = createAgreementFromViewing(viewing.id, {
+        sellerName: '田中',
+        sellerEmail: 'a@b.com',
+        buyerName: '山田',
+        buyerEmail: 'c@d.com',
+        propertyTitle: 'テスト',
+        handoverFee: 10000,
+      });
+
+      expect(() => signAgreement(agreement.id, { name: '山田花子' })).toThrow(
+        '受諾済みの合意のみ'
+      );
+    });
+
+    it('rejects signing already signed agreement', () => {
+      const viewing = createAgreedViewing();
+      const agreement = createAgreementFromViewing(viewing.id, {
+        sellerName: '田中',
+        sellerEmail: 'a@b.com',
+        buyerName: '山田',
+        buyerEmail: 'c@d.com',
+        propertyTitle: 'テスト',
+        handoverFee: 10000,
+      });
+      acceptAgreement(agreement.id);
+      signAgreement(agreement.id, { name: '山田花子' });
+
+      expect(() => signAgreement(agreement.id, { name: '山田花子' })).toThrow(
+        '受諾済みの合意のみ'
+      );
+    });
+  });
+
+  describe('agreement items from checklist', () => {
+    it('includes only keep items with correct metadata', () => {
+      const viewing = createAgreedViewing();
+      const agreement = createAgreementFromViewing(viewing.id, {
+        sellerName: '田中',
+        sellerEmail: 'a@b.com',
+        buyerName: '山田',
+        buyerEmail: 'c@d.com',
+        propertyTitle: 'テスト',
+        handoverFee: 30000,
+      });
+
+      // bed (keep, excellent, シングルベッド) and sofa (keep, fair, 3人掛け)
+      expect(agreement.items).toHaveLength(2);
+
+      const bed = agreement.items.find((i) => i.furnitureType === 'bed')!;
+      expect(bed.condition).toBe('excellent');
+      expect(bed.notes).toBe('シングルベッド');
+      expect(bed.photos).toEqual(['/bed.jpg']);
+
+      const sofa = agreement.items.find((i) => i.furnitureType === 'sofa')!;
+      expect(sofa.condition).toBe('fair');
+      expect(sofa.notes).toBe('3人掛け');
+    });
+  });
+});

--- a/src/lib/handover-agreement.ts
+++ b/src/lib/handover-agreement.ts
@@ -1,0 +1,212 @@
+/**
+ * 引き継ぎ合意管理
+ *
+ * 合意済み内見（agreed viewing）から引き継ぎ合意書を生成し、
+ * draft → pending_acceptance → signed のライフサイクルを管理する。
+ *
+ * チェックリストの「keep」アイテムのみを合意品目として抽出し、
+ * 残置物同意書PDFの元データとなる。
+ */
+
+import type { LargeFurnitureType } from './data';
+import { getViewing } from './viewing-flow';
+import { getChecklist } from './furniture-checklist';
+
+export interface AgreementItem {
+  id: string;
+  furnitureType: LargeFurnitureType;
+  photos: string[];
+  condition?: 'excellent' | 'good' | 'fair';
+  notes?: string;
+}
+
+export interface BuyerSignatureInput {
+  name: string;
+  ipAddress?: string;
+}
+
+export interface BuyerSignature {
+  name: string;
+  agreedAt: string;
+  ipAddress?: string;
+}
+
+export type AgreementStatus = 'draft' | 'pending_acceptance' | 'signed';
+
+export interface HandoverAgreementRecord {
+  id: string;
+  viewingId: string;
+  listingId: string;
+  checklistId: string;
+  items: AgreementItem[];
+  handoverFee: number;
+  status: AgreementStatus;
+  createdAt: string;
+  acceptedAt?: string;
+  signedAt?: string;
+  buyerSignature?: BuyerSignature;
+  sellerName: string;
+  sellerEmail: string;
+  buyerName: string;
+  buyerEmail: string;
+  propertyTitle: string;
+  propertyAddress?: string;
+}
+
+export interface CreateAgreementParams {
+  sellerName: string;
+  sellerEmail: string;
+  buyerName: string;
+  buyerEmail: string;
+  propertyTitle: string;
+  propertyAddress?: string;
+  handoverFee: number;
+}
+
+// In-memory store (mock, will be replaced with DB)
+let agreements: HandoverAgreementRecord[] = [];
+let nextId = 1;
+
+function generateId(): string {
+  return `ha-${nextId++}-${Date.now()}`;
+}
+
+/**
+ * Creates a handover agreement from an agreed viewing.
+ * Extracts keep-only items from the confirmed checklist.
+ * Returns existing agreement if one already exists for this viewing.
+ */
+export function createAgreementFromViewing(
+  viewingId: string,
+  params: CreateAgreementParams
+): HandoverAgreementRecord {
+  const existing = agreements.find((a) => a.viewingId === viewingId);
+  if (existing) return existing;
+
+  const viewing = getViewing(viewingId);
+  if (!viewing) {
+    throw new Error('内見が見つかりません');
+  }
+
+  if (viewing.status !== 'agreed') {
+    throw new Error('合意済みの内見のみから合意書を作成できます');
+  }
+
+  const checklist = getChecklist(viewing.checklistId);
+  if (!checklist) {
+    throw new Error('チェックリストが見つかりません');
+  }
+
+  // Extract keep-only items as agreement items
+  const items: AgreementItem[] = checklist.items
+    .filter((item) => item.disposition === 'keep')
+    .map((item) => ({
+      id: generateId(),
+      furnitureType: item.furnitureType,
+      photos: [...item.photos],
+      condition: item.condition,
+      notes: item.notes,
+    }));
+
+  const agreement: HandoverAgreementRecord = {
+    id: generateId(),
+    viewingId,
+    listingId: viewing.listingId,
+    checklistId: viewing.checklistId,
+    items,
+    handoverFee: params.handoverFee,
+    status: 'draft',
+    createdAt: new Date().toISOString(),
+    sellerName: params.sellerName,
+    sellerEmail: params.sellerEmail,
+    buyerName: params.buyerName,
+    buyerEmail: params.buyerEmail,
+    propertyTitle: params.propertyTitle,
+    propertyAddress: params.propertyAddress,
+  };
+
+  agreements = [...agreements, agreement];
+  return agreement;
+}
+
+/**
+ * Retrieves an agreement by ID.
+ */
+export function getAgreement(
+  agreementId: string
+): HandoverAgreementRecord | undefined {
+  return agreements.find((a) => a.id === agreementId);
+}
+
+/**
+ * Retrieves an agreement by viewing ID.
+ */
+export function getAgreementByViewing(
+  viewingId: string
+): HandoverAgreementRecord | undefined {
+  return agreements.find((a) => a.viewingId === viewingId);
+}
+
+/**
+ * Buyer accepts the agreement terms (draft → pending_acceptance).
+ */
+export function acceptAgreement(agreementId: string): HandoverAgreementRecord {
+  const agreement = agreements.find((a) => a.id === agreementId);
+  if (!agreement) {
+    throw new Error('合意書が見つかりません');
+  }
+
+  if (agreement.status !== 'draft') {
+    throw new Error('ドラフト状態の合意のみ受諾できます');
+  }
+
+  const updated: HandoverAgreementRecord = {
+    ...agreement,
+    status: 'pending_acceptance',
+    acceptedAt: new Date().toISOString(),
+  };
+
+  agreements = agreements.map((a) => (a.id === agreementId ? updated : a));
+  return updated;
+}
+
+/**
+ * Buyer signs the agreement (pending_acceptance → signed).
+ */
+export function signAgreement(
+  agreementId: string,
+  signature: BuyerSignatureInput
+): HandoverAgreementRecord {
+  const agreement = agreements.find((a) => a.id === agreementId);
+  if (!agreement) {
+    throw new Error('合意書が見つかりません');
+  }
+
+  if (agreement.status !== 'pending_acceptance') {
+    throw new Error('受諾済みの合意のみ署名できます');
+  }
+
+  const buyerSignature: BuyerSignature = {
+    name: signature.name,
+    agreedAt: new Date().toISOString(),
+    ipAddress: signature.ipAddress,
+  };
+
+  const updated: HandoverAgreementRecord = {
+    ...agreement,
+    status: 'signed',
+    signedAt: new Date().toISOString(),
+    buyerSignature,
+  };
+
+  agreements = agreements.map((a) => (a.id === agreementId ? updated : a));
+  return updated;
+}
+
+/**
+ * Resets all in-memory state. Used for testing.
+ */
+export function resetAgreementState(): void {
+  agreements = [];
+  nextId = 1;
+}


### PR DESCRIPTION
## Summary

- Implements `src/lib/handover-agreement.ts` — handover agreement lifecycle management
- Creates agreements from agreed viewings, extracting keep-only checklist items
- Manages `draft → pending_acceptance → signed` status transitions with validation
- Bridges viewing-flow, furniture-checklist, and consent PDF generation modules
- 12 unit tests covering creation, deduplication, acceptance, signing, and error cases

## Key Types & Functions

- `HandoverAgreementRecord` — agreement with viewing/checklist refs, parties, items, fee
- `createAgreementFromViewing()` — creates agreement from agreed viewing + confirmed checklist
- `acceptAgreement()` — buyer accepts terms (draft → pending_acceptance)
- `signAgreement()` — buyer signs with name/IP (pending_acceptance → signed)
- `getAgreement()` / `getAgreementByViewing()` — lookup functions

## Test plan

- [x] 12 unit tests pass (TDD: tests written first)
- [x] All 319 tests pass (no regressions)
- [ ] CI lint + type checks pass
- [ ] CI unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)