### PR TITLE
fix: add BETTER_AUTH_SECRET to E2E workflow and prevent deployment hangs

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: e2e-tests-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
   pull-requests: write
@@ -162,8 +166,7 @@ jobs:
         env:
           NODE_ENV: production
           DATABASE_URL: postgresql://tsumugi:tsumugi@localhost:5432/tsumugi_test
-          NEXTAUTH_URL: http://localhost:3000
-          NEXTAUTH_SECRET: test-secret-for-ci-builds-only
+          BETTER_AUTH_SECRET: test-secret-for-ci-builds-only
           S3_ENDPOINT: http://localhost:4566
           R2_BUCKET_NAME: tsumugi
 
@@ -181,6 +184,7 @@ jobs:
           CI: true
           BASE_URL: http://localhost:3000
           DATABASE_URL: postgresql://tsumugi:tsumugi@localhost:5432/tsumugi_test
+          BETTER_AUTH_SECRET: test-secret-for-ci-builds-only
           S3_ENDPOINT: http://localhost:4566
           R2_BUCKET_NAME: tsumugi
           STRIPE_SECRET_KEY: ${{ secrets.STRIPE_TEST_SECRET_KEY }}
@@ -282,6 +286,7 @@ jobs:
 
       - name: Deploy Playwright Report to GitHub Pages
         if: always()
+        timeout-minutes: 3
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- **Add `BETTER_AUTH_SECRET` env var** to both "Build Next.js app" and "Run E2E tests" steps — the app migrated to Better Auth but the CI still had stale `NEXTAUTH_URL`/`NEXTAUTH_SECRET`, causing every auth request to crash with `BetterAuthError`
- **Add `concurrency` group** to cancel stale runs when multiple commits are pushed to the same ref in quick succession
- **Add 3-minute timeout** to the gh-pages deployment step to prevent it from hanging indefinitely and consuming the full 20-minute job timeout

## Root Cause

E2E tests on `main` have been consistently failing/timing out because:

1. The Next.js server crashes on every auth-related request:
   ```
   Error [BetterAuthError]: You are using the default secret.
   Please set `BETTER_AUTH_SECRET` in your environment variables
   ```
2. After tests fail, the `peaceiris/actions-gh-pages@v3` deployment step hangs when concurrent pushes to `main` compete for the `gh-pages` branch lock, eating the entire 20-minute timeout
3. PR runs appeared green but were actually **skipping** E2E tests (no `e2e:` labels), masking the issue

## Test plan

- [ ] Verify E2E tests pass on this PR's CI run (the workflow itself runs on PRs with `e2e:run` label)
- [ ] After merge, verify E2E tests pass on `main` push
- [ ] Verify concurrent main pushes are handled cleanly (older runs cancelled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)