### PR TITLE
feat: add agreement PDF generation from signed agreements

### DIFF
--- a/src/lib/pdf/__tests__/agreement-pdf.test.ts
+++ b/src/lib/pdf/__tests__/agreement-pdf.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { buildAgreementPdfProps, generateAgreementPdf } from '../agreement-pdf';
+import {
+  createAgreementFromViewing,
+  acceptAgreement,
+  signAgreement,
+  resetAgreementState,
+} from '../../handover-agreement';
+import {
+  createViewing,
+  scheduleViewing,
+  completeViewing,
+  submitBuyerChecklist,
+  approveChecklist,
+  resetViewingState,
+} from '../../viewing-flow';
+import {
+  updateChecklistItem,
+  confirmChecklist,
+  getChecklist,
+  resetChecklistState,
+} from '../../furniture-checklist';
+import { resetMessagingState } from '../../messaging';
+import type { FurnitureItem } from '../../data';
+
+// Mock renderPdf to avoid actual PDF rendering in tests
+vi.mock('../render', () => ({
+  renderPdf: vi.fn().mockResolvedValue(Buffer.from('mock-pdf')),
+}));
+
+const FURNITURE_ITEMS: FurnitureItem[] = [
+  {
+    type: 'bed',
+    photos: ['/bed.jpg'],
+    condition: 'excellent',
+    notes: 'シングルベッド',
+  },
+  { type: 'desk', photos: ['/desk.jpg'], condition: 'good' },
+  { type: 'sofa', photos: ['/sofa.jpg'], condition: 'fair', notes: '3人掛け' },
+];
+
+function createSignedAgreement() {
+  const viewing = createViewing(
+    'listing-1',
+    'seller-1',
+    'buyer-1',
+    FURNITURE_ITEMS
+  );
+  scheduleViewing(viewing.id, '2026-02-15T10:00:00');
+  completeViewing(viewing.id);
+
+  const checklist = getChecklist(viewing.checklistId)!;
+  updateChecklistItem(checklist.id, checklist.items[0].id, 'keep'); // bed
+  updateChecklistItem(checklist.id, checklist.items[1].id, 'take_away'); // desk
+  updateChecklistItem(checklist.id, checklist.items[2].id, 'keep'); // sofa
+  confirmChecklist(checklist.id);
+
+  submitBuyerChecklist(viewing.id);
+  approveChecklist(viewing.id);
+
+  const agreement = createAgreementFromViewing(viewing.id, {
+    sellerName: '田中太郎',
+    sellerEmail: 'tanaka@example.com',
+    buyerName: '山田花子',
+    buyerEmail: 'yamada@example.com',
+    propertyTitle: '世田谷の家具付き物件',
+    propertyAddress: '世田谷区1-2-3',
+    handoverFee: 50000,
+  });
+  acceptAgreement(agreement.id);
+  signAgreement(agreement.id, { name: '山田花子', ipAddress: '192.168.1.1' });
+  return agreement;
+}
+
+describe('agreement-pdf', () => {
+  beforeEach(() => {
+    resetAgreementState();
+    resetViewingState();
+    resetChecklistState();
+    resetMessagingState();
+    vi.clearAllMocks();
+  });
+
+  describe('buildAgreementPdfProps', () => {
+    it('builds consent form props from a signed agreement', () => {
+      const agreement = createSignedAgreement();
+      const props = buildAgreementPdfProps(agreement.id);
+
+      expect(props.propertyAddress).toBe('世田谷区1-2-3');
+      expect(props.sellerName).toBe('田中太郎');
+      expect(props.buyerName).toBe('山田花子');
+      expect(props.furnitureItems).toHaveLength(2);
+      expect(props.createdDate).toBeTruthy();
+    });
+
+    it('includes correct furniture item details', () => {
+      const agreement = createSignedAgreement();
+      const props = buildAgreementPdfProps(agreement.id);
+
+      const bedItem = props.furnitureItems.find((i) => i.name === 'ベッド');
+      expect(bedItem).toBeDefined();
+      expect(bedItem!.condition).toBeTruthy(); // has a condition label
+
+      const sofaItem = props.furnitureItems.find((i) => i.name === 'ソファ');
+      expect(sofaItem).toBeDefined();
+      expect(sofaItem!.remarks).toBe('3人掛け');
+    });
+
+    it('throws for non-existent agreement', () => {
+      expect(() => buildAgreementPdfProps('nonexistent')).toThrow(
+        '合意書が見つかりません'
+      );
+    });
+
+    it('throws for non-signed agreement', () => {
+      const viewing = createViewing(
+        'listing-1',
+        'seller-1',
+        'buyer-1',
+        FURNITURE_ITEMS
+      );
+      scheduleViewing(viewing.id, '2026-02-15T10:00:00');
+      completeViewing(viewing.id);
+
+      const checklist = getChecklist(viewing.checklistId)!;
+      updateChecklistItem(checklist.id, checklist.items[0].id, 'keep');
+      updateChecklistItem(checklist.id, checklist.items[1].id, 'take_away');
+      updateChecklistItem(checklist.id, checklist.items[2].id, 'keep');
+      confirmChecklist(checklist.id);
+
+      submitBuyerChecklist(viewing.id);
+      approveChecklist(viewing.id);
+
+      const agreement = createAgreementFromViewing(viewing.id, {
+        sellerName: '田中',
+        sellerEmail: 'a@b.com',
+        buyerName: '山田',
+        buyerEmail: 'c@d.com',
+        propertyTitle: 'テスト',
+        handoverFee: 10000,
+      });
+
+      expect(() => buildAgreementPdfProps(agreement.id)).toThrow(
+        '署名済みの合意書のみ'
+      );
+    });
+  });
+
+  describe('generateAgreementPdf', () => {
+    it('returns a PDF buffer', async () => {
+      const agreement = createSignedAgreement();
+      const buffer = await generateAgreementPdf(agreement.id);
+
+      expect(buffer).toBeInstanceOf(Buffer);
+      expect(buffer.length).toBeGreaterThan(0);
+    });
+
+    it('calls renderPdf with ConsentForm component', async () => {
+      const { renderPdf } = await import('../render');
+      const agreement = createSignedAgreement();
+      await generateAgreementPdf(agreement.id);
+
+      expect(renderPdf).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/lib/pdf/agreement-pdf.ts
+++ b/src/lib/pdf/agreement-pdf.ts
@@ -1,0 +1,65 @@
+/**
+ * 残置物同意書PDF生成（引き継ぎ合意書からPDF出力）
+ *
+ * 署名済みのHandoverAgreementRecordからConsentFormテンプレートの
+ * propsを構築し、PDFバッファを生成する。
+ */
+
+import { createElement } from 'react';
+import { getAgreement } from '../handover-agreement';
+import { getChecklist } from '../furniture-checklist';
+import { buildConsentFormProps } from './consent-generator';
+import { ConsentForm } from './templates/consent-form';
+import { renderPdf } from './render';
+
+interface AgreementPdfProps {
+  propertyAddress: string;
+  roomNumber?: string;
+  sellerName: string;
+  buyerName?: string;
+  furnitureItems: Array<{
+    name: string;
+    category: string;
+    condition?: string;
+    remarks?: string;
+  }>;
+  createdDate: string;
+}
+
+/**
+ * Builds consent form PDF props from a signed agreement.
+ * The agreement must be in 'signed' status.
+ */
+export function buildAgreementPdfProps(agreementId: string): AgreementPdfProps {
+  const agreement = getAgreement(agreementId);
+  if (!agreement) {
+    throw new Error('合意書が見つかりません');
+  }
+
+  if (agreement.status !== 'signed') {
+    throw new Error('署名済みの合意書のみPDFを生成できます');
+  }
+
+  const checklist = getChecklist(agreement.checklistId);
+  if (!checklist) {
+    throw new Error('チェックリストが見つかりません');
+  }
+
+  return buildConsentFormProps({
+    propertyAddress: agreement.propertyAddress ?? '',
+    sellerName: agreement.sellerName,
+    buyerName: agreement.buyerName,
+    checklistItems: checklist.items,
+  });
+}
+
+/**
+ * Generates a PDF buffer for a signed handover agreement.
+ */
+export async function generateAgreementPdf(
+  agreementId: string
+): Promise<Buffer> {
+  const props = buildAgreementPdfProps(agreementId);
+  const element = createElement(ConsentForm, props);
+  return renderPdf(element);
+}

--- a/src/lib/pdf/index.ts
+++ b/src/lib/pdf/index.ts
@@ -9,3 +9,4 @@ export {
   buildConsentFormProps,
   mapChecklistToConsentItems,
 } from './consent-generator';
+export { buildAgreementPdfProps, generateAgreementPdf } from './agreement-pdf';


### PR DESCRIPTION
## Summary

- Adds `src/lib/pdf/agreement-pdf.ts` — generates PDF from signed handover agreements
- `buildAgreementPdfProps()` — builds ConsentForm props from a signed `HandoverAgreementRecord`
- `generateAgreementPdf()` — renders the ConsentForm template to a PDF buffer
- Bridges handover-agreement module → consent-generator → ConsentForm template → renderPdf
- Exports new functions from `src/lib/pdf/index.ts`
- 6 unit tests covering props building, furniture details, error cases, and PDF generation

## Test plan

- [x] 6 unit tests pass (TDD: tests written first)
- [x] All 325 tests pass (no regressions)
- [ ] CI lint + type checks pass
- [ ] CI unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)