### PR TITLE
feat: add cancellation penalty calculation module

### DIFF
--- a/src/lib/__tests__/cancellation-penalty.test.ts
+++ b/src/lib/__tests__/cancellation-penalty.test.ts
@@ -153,6 +153,58 @@ describe('cancellation-penalty', () => {
     });
   });
 
+  describe('edge cases', () => {
+    it('caps penalty at totalPaid when totalPaid < minimum penalty', () => {
+      const input: CancellationInput = {
+        cancelledBy: 'buyer',
+        phase: 'post_remaining_payment',
+        handoverFee: 50000,
+        depositPaid: DEPOSIT_AMOUNT,
+        remainingPaid: 5000,
+      };
+      const result = calculatePenalty(input);
+      // totalPaid = 25000, rawPenalty = 10000, clamped to 30000, but capped at 25000
+      expect(result.penaltyAmount).toBe(25000);
+      expect(result.refundAmount).toBe(0);
+    });
+
+    it('rejects negative depositPaid', () => {
+      expect(() =>
+        calculatePenalty({
+          cancelledBy: 'buyer',
+          phase: 'post_deposit',
+          handoverFee: 80000,
+          depositPaid: -5000,
+          remainingPaid: 0,
+        })
+      ).toThrow('金額は0以上');
+    });
+
+    it('rejects negative remainingPaid', () => {
+      expect(() =>
+        calculatePenalty({
+          cancelledBy: 'seller',
+          phase: 'post_remaining_payment',
+          handoverFee: 80000,
+          depositPaid: DEPOSIT_AMOUNT,
+          remainingPaid: -1000,
+        })
+      ).toThrow('金額は0以上');
+    });
+
+    it('rejects negative handoverFee', () => {
+      expect(() =>
+        calculatePenalty({
+          cancelledBy: 'buyer',
+          phase: 'post_remaining_payment',
+          handoverFee: -10000,
+          depositPaid: DEPOSIT_AMOUNT,
+          remainingPaid: 0,
+        })
+      ).toThrow('金額は0以上');
+    });
+  });
+
   describe('result structure', () => {
     it('includes all required fields', () => {
       const input: CancellationInput = {

--- a/src/lib/cancellation-penalty.ts
+++ b/src/lib/cancellation-penalty.ts
@@ -58,6 +58,11 @@ export interface CancellationResult {
  */
 export function calculatePenalty(input: CancellationInput): CancellationResult {
   const { cancelledBy, phase, handoverFee, depositPaid, remainingPaid } = input;
+
+  if (depositPaid < 0 || remainingPaid < 0 || handoverFee < 0) {
+    throw new Error('金額は0以上である必要があります');
+  }
+
   const totalPaid = depositPaid + remainingPaid;
 
   // Pre-viewing: always free
@@ -109,10 +114,11 @@ export function calculatePenalty(input: CancellationInput): CancellationResult {
 
   // Buyer cancellation post-remaining payment
   const rawPenalty = handoverFee * PENALTY_RATE;
-  const penaltyAmount = Math.min(
+  const clampedPenalty = Math.min(
     PENALTY_MAX,
     Math.max(PENALTY_MIN, rawPenalty)
   );
+  const penaltyAmount = Math.min(totalPaid, clampedPenalty);
   const refundAmount = totalPaid - penaltyAmount;
 
   return {


### PR DESCRIPTION
## Summary

- Adds `src/lib/cancellation-penalty.ts` — cancellation penalty and refund calculation
- Implements business rules from `payment.md §12.5` and `BUSINESS.md`:
  - Pre-viewing: free cancellation for all parties
  - Post-deposit: buyer forfeits ¥20,000; seller/screening/mutual = full refund
  - Post-remaining: buyer pays 20% of handover fee (min ¥30,000, max ¥50,000)
- Pure function `calculatePenalty()` — no side effects, no state
- Input validation: rejects negative payment amounts
- Penalty capped at totalPaid to prevent reporting uncollectible amounts
- 15 unit tests covering all cancellation scenarios + edge cases

## Changes after review

- Added input validation for negative amounts (throws on negative depositPaid/remainingPaid/handoverFee)
- Added `Math.min(totalPaid, clampedPenalty)` to cap penalty at what was actually paid
- Added 4 new edge case tests

## Test plan

- [x] 15 unit tests pass (TDD + review fixes)
- [x] All 340 tests pass (no regressions)
- [ ] CI lint + type checks pass
- [ ] CI unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)