### PR TITLE
feat: add notification email templates for handover flow

### DIFF
--- a/src/lib/email/__tests__/notification-templates.test.tsx
+++ b/src/lib/email/__tests__/notification-templates.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@react-email/components';
+import { InquiryNotification } from '../templates/inquiry-notification';
+import { ViewingScheduled } from '../templates/viewing-scheduled';
+import { ChecklistConfirmed } from '../templates/checklist-confirmed';
+
+describe('InquiryNotification (F-204)', () => {
+  it('renders seller notification with buyer info', async () => {
+    const html = await render(
+      <InquiryNotification
+        sellerName="田中太郎"
+        buyerName="山田花子"
+        propertyTitle="世田谷の家具付き物件"
+        dashboardUrl="https://tsumugi.com/dashboard"
+        message="内見を希望しています"
+      />
+    );
+    expect(html).toContain('田中太郎');
+    expect(html).toContain('山田花子');
+    expect(html).toContain('世田谷の家具付き物件');
+    expect(html).toContain('問い合わせが届きました');
+    expect(html).toContain('内見を希望しています');
+  });
+
+  it('renders without message', async () => {
+    const html = await render(
+      <InquiryNotification
+        sellerName="田中"
+        buyerName="山田"
+        propertyTitle="テスト物件"
+        dashboardUrl="https://tsumugi.com/dashboard"
+      />
+    );
+    expect(html).toContain('田中');
+    expect(html).not.toContain('メッセージ');
+  });
+});
+
+describe('ViewingScheduled', () => {
+  it('renders viewing date and property info', async () => {
+    const html = await render(
+      <ViewingScheduled
+        recipientName="田中太郎"
+        otherPartyName="山田花子"
+        propertyTitle="世田谷の物件"
+        viewingDate="2026年2月15日 10:00"
+        propertyUrl="https://tsumugi.com/listings/1"
+      />
+    );
+    expect(html).toContain('田中太郎');
+    expect(html).toContain('2026年2月15日 10:00');
+    expect(html).toContain('世田谷の物件');
+    expect(html).toContain('内見日程が確定しました');
+  });
+});
+
+describe('ChecklistConfirmed', () => {
+  it('renders confirmed items count and parties', async () => {
+    const html = await render(
+      <ChecklistConfirmed
+        recipientName="山田花子"
+        propertyTitle="世田谷の物件"
+        keepCount={3}
+        takeAwayCount={1}
+        dashboardUrl="https://tsumugi.com/dashboard"
+      />
+    );
+    expect(html).toContain('山田花子');
+    expect(html).toContain('世田谷の物件');
+    expect(html).toContain('3');
+    expect(html).toContain('引き継ぎ');
+  });
+});

--- a/src/lib/email/templates/checklist-confirmed.tsx
+++ b/src/lib/email/templates/checklist-confirmed.tsx
@@ -1,0 +1,103 @@
+import { Button, Heading, Text } from '@react-email/components';
+import { BaseLayout } from './base-layout';
+
+interface ChecklistConfirmedProps {
+  recipientName: string;
+  propertyTitle: string;
+  keepCount: number;
+  takeAwayCount: number;
+  dashboardUrl: string;
+}
+
+/**
+ * 家具リスト確定通知（双方へ送信）
+ */
+export function ChecklistConfirmed({
+  recipientName,
+  propertyTitle,
+  keepCount,
+  takeAwayCount,
+  dashboardUrl,
+}: ChecklistConfirmedProps) {
+  return (
+    <BaseLayout preview={`${propertyTitle}の引き継ぎリストが確定しました`}>
+      <Heading as="h2" style={styles.heading}>
+        引き継ぎリストが確定しました
+      </Heading>
+
+      <Text style={styles.text}>{recipientName} 様</Text>
+
+      <Text style={styles.text}>
+        「{propertyTitle}」の家具引き継ぎリストが確定しました。
+      </Text>
+
+      <Text style={styles.detail}>
+        <strong>引き継ぎ品目:</strong> {keepCount}点
+      </Text>
+      <Text style={styles.detail}>
+        <strong>引き取らない品目:</strong> {takeAwayCount}点
+      </Text>
+
+      <Text style={styles.text}>
+        次のステップとして、引き継ぎ合意書の確認・署名に進みます。
+      </Text>
+
+      <Button href={dashboardUrl} style={styles.button}>
+        ダッシュボードで確認する
+      </Button>
+
+      <Text style={styles.note}>
+        ※
+        内容に疑問がある場合は、ダッシュボードのメッセージ機能でご連絡ください。
+      </Text>
+    </BaseLayout>
+  );
+}
+
+const styles = {
+  heading: {
+    color: '#333333',
+    fontSize: '20px',
+    fontWeight: '600' as const,
+    margin: '0 0 16px',
+  },
+  text: {
+    color: '#555555',
+    fontSize: '14px',
+    lineHeight: '24px',
+    margin: '0 0 12px',
+  },
+  detail: {
+    backgroundColor: '#f9f9f9',
+    borderLeft: '3px solid #FF5A5F',
+    color: '#333333',
+    fontSize: '14px',
+    margin: '8px 0',
+    padding: '10px 16px',
+  },
+  button: {
+    backgroundColor: '#FF5A5F',
+    borderRadius: '6px',
+    color: '#ffffff',
+    display: 'inline-block',
+    fontSize: '14px',
+    fontWeight: '600' as const,
+    margin: '16px 0',
+    padding: '12px 24px',
+    textDecoration: 'none',
+    textAlign: 'center' as const,
+  },
+  note: {
+    color: '#999999',
+    fontSize: '12px',
+    margin: '16px 0 0',
+  },
+};
+
+ChecklistConfirmed.PreviewProps = {
+  recipientName: '山田花子',
+  propertyTitle: '世田谷区の家具付き物件',
+  keepCount: 3,
+  takeAwayCount: 1,
+  dashboardUrl: 'https://tsumugi.com/dashboard',
+} satisfies ChecklistConfirmedProps;

--- a/src/lib/email/templates/inquiry-notification.tsx
+++ b/src/lib/email/templates/inquiry-notification.tsx
@@ -1,0 +1,119 @@
+import { Button, Heading, Text } from '@react-email/components';
+import { BaseLayout } from './base-layout';
+
+interface InquiryNotificationProps {
+  sellerName: string;
+  buyerName: string;
+  propertyTitle: string;
+  dashboardUrl: string;
+  message?: string;
+}
+
+/**
+ * F-204: 問い合わせ受付通知（前の住人へ自動送信）
+ */
+export function InquiryNotification({
+  sellerName,
+  buyerName,
+  propertyTitle,
+  dashboardUrl,
+  message,
+}: InquiryNotificationProps) {
+  return (
+    <BaseLayout preview={`${propertyTitle}に問い合わせが届きました`}>
+      <Heading as="h2" style={styles.heading}>
+        問い合わせが届きました
+      </Heading>
+
+      <Text style={styles.text}>{sellerName} 様</Text>
+
+      <Text style={styles.text}>
+        あなたの物件「{propertyTitle}
+        」に次の住人候補から問い合わせが届きました。
+      </Text>
+
+      <Text style={styles.detail}>
+        <strong>次の住人候補:</strong> {buyerName}
+      </Text>
+
+      {message && (
+        <>
+          <Text style={styles.label}>メッセージ:</Text>
+          <Text style={styles.messageBox}>{message}</Text>
+        </>
+      )}
+
+      <Button href={dashboardUrl} style={styles.button}>
+        ダッシュボードで確認する
+      </Button>
+
+      <Text style={styles.note}>
+        ※ 48時間以内にご返信いただくことをお勧めします。
+      </Text>
+    </BaseLayout>
+  );
+}
+
+const styles = {
+  heading: {
+    color: '#333333',
+    fontSize: '20px',
+    fontWeight: '600' as const,
+    margin: '0 0 16px',
+  },
+  text: {
+    color: '#555555',
+    fontSize: '14px',
+    lineHeight: '24px',
+    margin: '0 0 12px',
+  },
+  detail: {
+    backgroundColor: '#f9f9f9',
+    borderLeft: '3px solid #FF5A5F',
+    color: '#333333',
+    fontSize: '14px',
+    margin: '16px 0',
+    padding: '12px 16px',
+  },
+  label: {
+    color: '#888888',
+    fontSize: '12px',
+    margin: '16px 0 4px',
+    textTransform: 'uppercase' as const,
+  },
+  messageBox: {
+    backgroundColor: '#f9f9f9',
+    borderRadius: '6px',
+    color: '#555555',
+    fontSize: '14px',
+    lineHeight: '22px',
+    margin: '0 0 16px',
+    padding: '12px 16px',
+    whiteSpace: 'pre-wrap' as const,
+  },
+  button: {
+    backgroundColor: '#FF5A5F',
+    borderRadius: '6px',
+    color: '#ffffff',
+    display: 'inline-block',
+    fontSize: '14px',
+    fontWeight: '600' as const,
+    margin: '16px 0',
+    padding: '12px 24px',
+    textDecoration: 'none',
+    textAlign: 'center' as const,
+  },
+  note: {
+    color: '#999999',
+    fontSize: '12px',
+    margin: '16px 0 0',
+  },
+};
+
+InquiryNotification.PreviewProps = {
+  sellerName: '田中太郎',
+  buyerName: '山田花子',
+  propertyTitle: '渋谷区神宮前 1LDK｜北欧スタイルのワンルーム',
+  dashboardUrl: 'https://tsumugi.com/dashboard',
+  message: 'こちらの物件に興味があります。内見は可能でしょうか？',
+} satisfies InquiryNotificationProps;

--- a/src/lib/email/templates/viewing-scheduled.tsx
+++ b/src/lib/email/templates/viewing-scheduled.tsx
@@ -1,0 +1,102 @@
+import { Button, Heading, Text } from '@react-email/components';
+import { BaseLayout } from './base-layout';
+
+interface ViewingScheduledProps {
+  recipientName: string;
+  otherPartyName: string;
+  propertyTitle: string;
+  viewingDate: string;
+  propertyUrl: string;
+}
+
+/**
+ * 内見確定通知（双方へ送信）
+ */
+export function ViewingScheduled({
+  recipientName,
+  otherPartyName,
+  propertyTitle,
+  viewingDate,
+  propertyUrl,
+}: ViewingScheduledProps) {
+  return (
+    <BaseLayout preview={`${propertyTitle}の内見日程が確定しました`}>
+      <Heading as="h2" style={styles.heading}>
+        内見日程が確定しました
+      </Heading>
+
+      <Text style={styles.text}>{recipientName} 様</Text>
+
+      <Text style={styles.text}>
+        以下の物件の内見日程が確定しました。当日はお気をつけてお越しください。
+      </Text>
+
+      <Text style={styles.detail}>
+        <strong>物件:</strong> {propertyTitle}
+      </Text>
+      <Text style={styles.detail}>
+        <strong>日時:</strong> {viewingDate}
+      </Text>
+      <Text style={styles.detail}>
+        <strong>相手:</strong> {otherPartyName}
+      </Text>
+
+      <Button href={propertyUrl} style={styles.button}>
+        物件詳細を見る
+      </Button>
+
+      <Text style={styles.note}>
+        ※
+        日程の変更が必要な場合は、ダッシュボードのメッセージ機能でご連絡ください。
+      </Text>
+    </BaseLayout>
+  );
+}
+
+const styles = {
+  heading: {
+    color: '#333333',
+    fontSize: '20px',
+    fontWeight: '600' as const,
+    margin: '0 0 16px',
+  },
+  text: {
+    color: '#555555',
+    fontSize: '14px',
+    lineHeight: '24px',
+    margin: '0 0 12px',
+  },
+  detail: {
+    backgroundColor: '#f9f9f9',
+    borderLeft: '3px solid #FF5A5F',
+    color: '#333333',
+    fontSize: '14px',
+    margin: '8px 0',
+    padding: '10px 16px',
+  },
+  button: {
+    backgroundColor: '#FF5A5F',
+    borderRadius: '6px',
+    color: '#ffffff',
+    display: 'inline-block',
+    fontSize: '14px',
+    fontWeight: '600' as const,
+    margin: '16px 0',
+    padding: '12px 24px',
+    textDecoration: 'none',
+    textAlign: 'center' as const,
+  },
+  note: {
+    color: '#999999',
+    fontSize: '12px',
+    margin: '16px 0 0',
+  },
+};
+
+ViewingScheduled.PreviewProps = {
+  recipientName: '田中太郎',
+  otherPartyName: '山田花子',
+  propertyTitle: '世田谷区の家具付き物件',
+  viewingDate: '2026年2月15日（日）10:00',
+  propertyUrl: 'https://tsumugi.com/listings/1',
+} satisfies ViewingScheduledProps;


### PR DESCRIPTION
## Summary

- Add `InquiryNotification` template — seller notification when buyer inquires (F-204)
- Add `ViewingScheduled` template — viewing date confirmed notification (both parties)
- Add `ChecklistConfirmed` template — furniture checklist confirmed notification (both parties)

All templates use the existing `BaseLayout` and follow the coral accent + Japanese copy pattern established in `inquiry-confirmation.tsx`.

## Test plan

- [x] 4 unit tests covering all 3 templates (renders content, optional message handling)
- [x] All 344 tests pass locally (`bun run test:run`)
- [ ] CI passes (lint, types, unit tests, E2E)

🤖 Generated with [Claude Code](https://claude.com/claude-code)