### PR TITLE
feat: add payment refund processing with cancellation penalty integration

### DIFF
--- a/src/app/actions/__tests__/refund.test.ts
+++ b/src/app/actions/__tests__/refund.test.ts
@@ -283,6 +283,17 @@ describe('processRefund', () => {
     expect(result.error).toBe('No payments found for this property');
   });
 
+  it('should reject invalid input with Zod validation', async () => {
+    const result = await processRefund({
+      propertyId: '',
+      cancelledBy: 'invalid' as any,
+      phase: 'pre_viewing',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('入力が不正です');
+  });
+
   it('should handle Stripe API errors gracefully', async () => {
     vi.mocked(db.query.properties.findFirst).mockResolvedValue({
       id: mockPropertyId,

--- a/src/app/actions/refund.ts
+++ b/src/app/actions/refund.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { randomUUID } from 'crypto';
+import zod from 'zod';
 import { stripe } from '@/lib/stripe/server';
 import { db } from '@/db';
 import { payments, transactions, properties } from '@/db/schema';
@@ -11,6 +12,12 @@ import {
   type CancelledBy,
   type CancellationPhase,
 } from '@/lib/cancellation-penalty';
+
+const processRefundSchema = zod.object({
+  propertyId: zod.string().min(1),
+  cancelledBy: zod.enum(['buyer', 'seller', 'screening_failure', 'mutual']),
+  phase: zod.enum(['pre_viewing', 'post_deposit', 'post_remaining_payment']),
+});
 
 export interface ProcessRefundInput {
   propertyId: string;
@@ -44,7 +51,8 @@ export async function processRefund(
   input: ProcessRefundInput
 ): Promise<ProcessRefundResult> {
   try {
-    const { propertyId, cancelledBy, phase } = input;
+    const validated = processRefundSchema.parse(input);
+    const { propertyId, cancelledBy, phase } = validated;
 
     // Get property details
     const property = await db.query.properties.findFirst({
@@ -190,6 +198,12 @@ export async function processRefund(
       refundIds: refundIds.length > 0 ? refundIds : undefined,
     };
   } catch (error) {
+    if (error instanceof zod.ZodError) {
+      return {
+        success: false,
+        error: `入力が不正です: ${error.errors.map((e) => e.message).join(', ')}`,
+      };
+    }
     return {
       success: false,
       error: error instanceof Error ? error.message : 'Unknown error occurred',


### PR DESCRIPTION
## Summary

- Add `processRefund()` server action that bridges cancellation penalty calculation with Stripe refund execution
- Handles all cancellation scenarios (buyer/seller/screening/mutual) across payment phases
- Cancels pending PaymentIntents and refunds succeeded payments based on penalty rules
- Integrates with existing `calculatePenalty()` module for business rule compliance

## Key behaviors

| Scenario | App Fee | Deposit | Remaining |
|----------|---------|---------|-----------|
| Pre-viewing (any) | Refunded | N/A | N/A |
| Buyer post-deposit | Not refunded | Forfeited | N/A |
| Seller/screening/mutual | Refunded | Refunded | Refunded |
| Buyer post-remaining | Not refunded | Penalty applied | Penalty applied |

## Review feedback addressed

- Fixed wrong table reference in WHERE clause (`payments.propertyId` -> `properties.id`)
- Wrapped all DB operations in `db.transaction()` for atomicity
- Use `'refunded'` status for refunded payments (distinct from `'canceled'`)
- Added TODO for auth checks (consistent with other payment actions that also lack auth pre-Phase 2)

## Test plan

- [x] 8 unit tests covering all cancellation scenarios
- [x] All 352 tests pass locally (`bun run test:run`)
- [ ] CI passes (lint, types, unit tests, E2E)

🤖 Generated with [Claude Code](https://claude.com/claude-code)