### PR TITLE
feat: add email_logs table and management company email field

### DIFF
--- a/src/db/migrations/0002_management-company-email-logs.sql
+++ b/src/db/migrations/0002_management-company-email-logs.sql
@@ -1,0 +1,31 @@
+-- Management Company Integration: email field + email_logs table
+-- Refs: TSU-20, task 3j1
+
+-- ============================================================
+-- 1. Properties: Add management company email
+-- ============================================================
+ALTER TABLE "properties" ADD COLUMN "management_company_email" varchar(320);
+--> statement-breakpoint
+
+-- ============================================================
+-- 2. Email Logs table (sending history)
+-- ============================================================
+CREATE TABLE "email_logs" (
+	"id" text PRIMARY KEY NOT NULL,
+	"property_id" text NOT NULL,
+	"recipient_email" varchar(320) NOT NULL,
+	"email_type" varchar(50) NOT NULL,
+	"subject" varchar(500) NOT NULL,
+	"sent_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"status" varchar(20) DEFAULT 'sent' NOT NULL,
+	"pdf_url" text,
+	"metadata" jsonb
+);
+--> statement-breakpoint
+ALTER TABLE "email_logs" ADD CONSTRAINT "email_logs_property_id_properties_id_fk" FOREIGN KEY ("property_id") REFERENCES "public"."properties"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+CREATE INDEX "idx_email_logs_property_id" ON "email_logs" USING btree ("property_id");
+--> statement-breakpoint
+CREATE INDEX "idx_email_logs_email_type" ON "email_logs" USING btree ("email_type");
+--> statement-breakpoint
+CREATE INDEX "idx_email_logs_sent_at" ON "email_logs" USING btree ("sent_at");

--- a/src/db/schema/__tests__/email-logs.test.ts
+++ b/src/db/schema/__tests__/email-logs.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { emailLogs } from '../email-logs';
+import { getTableColumns } from 'drizzle-orm';
+
+describe('emailLogs schema', () => {
+  it('should have all required columns', () => {
+    const columns = getTableColumns(emailLogs);
+
+    expect(columns.id).toBeDefined();
+    expect(columns.propertyId).toBeDefined();
+    expect(columns.recipientEmail).toBeDefined();
+    expect(columns.emailType).toBeDefined();
+    expect(columns.subject).toBeDefined();
+    expect(columns.sentAt).toBeDefined();
+    expect(columns.status).toBeDefined();
+    expect(columns.pdfUrl).toBeDefined();
+    expect(columns.metadata).toBeDefined();
+  });
+
+  it('should have correct column types', () => {
+    const columns = getTableColumns(emailLogs);
+
+    expect(columns.id.dataType).toBe('string');
+    expect(columns.propertyId.dataType).toBe('string');
+    expect(columns.recipientEmail.dataType).toBe('string');
+    expect(columns.emailType.dataType).toBe('string');
+    expect(columns.subject.dataType).toBe('string');
+    expect(columns.status.dataType).toBe('string');
+  });
+
+  it('should require id, propertyId, recipientEmail, emailType, and subject', () => {
+    const columns = getTableColumns(emailLogs);
+
+    expect(columns.id.notNull).toBe(true);
+    expect(columns.propertyId.notNull).toBe(true);
+    expect(columns.recipientEmail.notNull).toBe(true);
+    expect(columns.emailType.notNull).toBe(true);
+    expect(columns.subject.notNull).toBe(true);
+  });
+
+  it('should default status to sent', () => {
+    const columns = getTableColumns(emailLogs);
+
+    expect(columns.status.hasDefault).toBe(true);
+  });
+});

--- a/src/db/schema/email-logs.ts
+++ b/src/db/schema/email-logs.ts
@@ -1,0 +1,51 @@
+import {
+  pgTable,
+  varchar,
+  text,
+  timestamp,
+  jsonb,
+  index,
+} from 'drizzle-orm/pg-core';
+import { properties } from './properties';
+
+export type EmailType =
+  | 'management_company_agreement'
+  | 'management_company_faq'
+  | 'management_company_notification';
+
+export type EmailLogStatus = 'sent' | 'failed' | 'bounced';
+
+export interface EmailLogMetadata {
+  resendMessageId?: string;
+  attachmentUrls?: string[];
+  error?: string;
+}
+
+export const emailLogs = pgTable(
+  'email_logs',
+  {
+    id: text('id').primaryKey().notNull(),
+    propertyId: text('property_id')
+      .notNull()
+      .references(() => properties.id, { onDelete: 'cascade' }),
+    recipientEmail: varchar('recipient_email', { length: 320 }).notNull(),
+    emailType: varchar('email_type', { length: 50 })
+      .$type<EmailType>()
+      .notNull(),
+    subject: varchar('subject', { length: 500 }).notNull(),
+    sentAt: timestamp('sent_at', { withTimezone: true }).defaultNow().notNull(),
+    status: varchar('status', { length: 20 })
+      .$type<EmailLogStatus>()
+      .default('sent')
+      .notNull(),
+    pdfUrl: text('pdf_url'),
+    metadata: jsonb('metadata').$type<EmailLogMetadata>(),
+  },
+  (table) => {
+    return {
+      propertyIdIdx: index('idx_email_logs_property_id').on(table.propertyId),
+      emailTypeIdx: index('idx_email_logs_email_type').on(table.emailType),
+      sentAtIdx: index('idx_email_logs_sent_at').on(table.sentAt),
+    };
+  }
+);

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -17,6 +17,12 @@ export {
   verificationTokens,
 } from './sessions';
 export { payments, transactions, stripeAccounts } from './payments';
+export {
+  emailLogs,
+  type EmailType,
+  type EmailLogStatus,
+  type EmailLogMetadata,
+} from './email-logs';
 
 // Define relations
 import { relations } from 'drizzle-orm';
@@ -26,6 +32,7 @@ import { inquiries } from './inquiries';
 import { threads, messages } from './messages';
 import { sessions, accounts } from './sessions';
 import { payments, transactions, stripeAccounts } from './payments';
+import { emailLogs } from './email-logs';
 
 // User relations
 export const usersRelations = relations(users, ({ one, many }) => ({
@@ -61,6 +68,7 @@ export const propertiesRelations = relations(properties, ({ one, many }) => ({
   inquiries: many(inquiries),
   payments: many(payments),
   threads: many(threads),
+  emailLogs: many(emailLogs),
 }));
 
 // Inquiry relations
@@ -148,5 +156,13 @@ export const messagesRelations = relations(messages, ({ one }) => ({
   sender: one(users, {
     fields: [messages.senderId],
     references: [users.id],
+  }),
+}));
+
+// Email Log relations
+export const emailLogsRelations = relations(emailLogs, ({ one }) => ({
+  property: one(properties, {
+    fields: [emailLogs.propertyId],
+    references: [properties.id],
   }),
 }));

--- a/src/db/schema/properties.ts
+++ b/src/db/schema/properties.ts
@@ -117,6 +117,9 @@ export const properties = pgTable(
 
     // Management Company
     managementCompanyName: varchar('management_company_name', { length: 255 }),
+    managementCompanyEmail: varchar('management_company_email', {
+      length: 320,
+    }),
     managementConsultedAt: timestamp('management_consulted_at', {
       withTimezone: true,
     }),


### PR DESCRIPTION
## Summary

- Add `emailLogs` database table for tracking emails sent to management companies (agreement PDFs, notifications)
- Add `managementCompanyEmail` varchar field to `properties` table
- Create migration `0002_management-company-email-logs.sql` with proper indexes and FK constraints
- Add schema relations connecting `emailLogs` to `properties`
- Add unit tests for emailLogs schema (4 tests)

Part 1 of management company integration (TSU-20 / 3j1). This PR adds the database foundation; subsequent PRs will add email template + server action + UI.

## Test plan

- [x] All 357 tests pass (353 existing + 4 new emailLogs schema tests)
- [x] Schema exports correctly from `@/db/schema`
- [x] Migration SQL is syntactically correct
- [x] No regressions in existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)