### PR TITLE
fix: widen renderPdf parameter type to accept component elements

### DIFF
--- a/src/lib/pdf/render.ts
+++ b/src/lib/pdf/render.ts
@@ -1,9 +1,8 @@
+import type { ReactElement } from 'react';
 import { renderToBuffer } from '@react-pdf/renderer';
 import { registerFonts } from './fonts';
 
-export async function renderPdf(
-  document: Parameters<typeof renderToBuffer>[0]
-): Promise<Buffer> {
+export async function renderPdf(document: ReactElement): Promise<Buffer> {
   registerFonts();
   const buffer = await renderToBuffer(document);
   return Buffer.from(buffer);


### PR DESCRIPTION
## Summary

- Widen `renderPdf` parameter type from `Parameters<typeof renderToBuffer>[0]` (`ReactElement<DocumentProps>`) to `ReactElement`
- This fixes the TypeScript build error blocking all E2E tests on `main` since the agreement PDF feature was merged

## Root Cause

`ConsentForm` wraps its content in `<Document>` internally, but `createElement(ConsentForm, props)` produces `ReactElement<ConsentFormProps>`, not `ReactElement<DocumentProps>`. The overly narrow type on `renderPdf` rejects this even though it renders correctly at runtime.

## Test plan

- [x] `tsc --noEmit` passes with no errors
- [x] All 16 PDF-related unit tests pass
- [ ] E2E tests should now get past the build step on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)