### PR TITLE
fix: cast document element for renderToBuffer type compatibility

### DIFF
--- a/src/lib/pdf/render.ts
+++ b/src/lib/pdf/render.ts
@@ -4,6 +4,8 @@ import { registerFonts } from './fonts';
 
 export async function renderPdf(document: ReactElement): Promise<Buffer> {
   registerFonts();
-  const buffer = await renderToBuffer(document);
+  const buffer = await renderToBuffer(
+    document as Parameters<typeof renderToBuffer>[0]
+  );
   return Buffer.from(buffer);
 }


### PR DESCRIPTION
## Summary

- Add explicit type cast at the `renderToBuffer` call site inside `renderPdf` to bridge the gap between `ReactElement` (accepted by callers) and `ReactElement<DocumentProps>` (required by `renderToBuffer`)
- Follow-up to #261 which widened the parameter type but moved the error to the internal call

## Context

Components like `ConsentForm` that wrap their content in `<Document>` produce valid document elements at runtime, but TypeScript can't infer `DocumentProps` from the component's own props type. The cast is safe because `renderPdf` is only called with components that render `<Document>`.

## Test plan

- [x] `tsc --noEmit` passes with no errors
- [x] All 16 PDF-related unit tests pass
- [ ] E2E tests should now get past the build step on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)