### PR TITLE
chore: fix devcontainer git submodule path resolution

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -72,6 +72,10 @@ ENV DEVCONTAINER=true
 RUN mkdir -p /workspace /home/bun/.claude && \
   chown -R bun:bun /workspace /home/bun/.claude
 
+# Create symlink so git submodule worktree path resolves inside container
+# (.git/modules/tsumugi/config has worktree = ../../../aspects/tsumugi)
+RUN mkdir -p /aspects && ln -s /workspace /aspects/tsumugi
+
 WORKDIR /workspace
 
 # Install git-delta for better diffs

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -5,13 +5,16 @@ services:
       dockerfile: Dockerfile
     volumes:
       - ..:/workspace:cached
+      - claude_config:/home/bun/.claude
+      # Mount parent repo's git module data so submodule .git reference resolves
+      - ../../../.git/modules/tsumugi:/.git/modules/tsumugi:cached
     command: sleep infinity
     cap_add:
       - NET_ADMIN
     deploy:
       resources:
         limits:
-          cpus: "6"
+          cpus: '6'
 
   postgres:
     image: postgres:16-alpine
@@ -24,7 +27,7 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U tsumugi"]
+      test: ['CMD-SHELL', 'pg_isready -U tsumugi']
       interval: 5s
       timeout: 5s
       retries: 5
@@ -39,10 +42,10 @@ services:
       - DEBUG=0
       - DEFAULT_REGION=ap-northeast-1
     volumes:
-      - "../scripts/localstack-init.sh:/etc/localstack/init/ready.d/init.sh"
+      - '../scripts/localstack-init.sh:/etc/localstack/init/ready.d/init.sh'
       - localstack_data:/var/lib/localstack
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:4566/_localstack/health"]
+      test: ['CMD', 'curl', '-f', 'http://localhost:4566/_localstack/health']
       interval: 5s
       timeout: 5s
       retries: 10
@@ -52,3 +55,4 @@ services:
 volumes:
   postgres_data:
   localstack_data:
+  claude_config:


### PR DESCRIPTION
## Summary
- Fix git submodule worktree path resolution inside devcontainer
- Add Claude config volume persistence across container rebuilds

## Changes
- **Dockerfile**: Add `/aspects/tsumugi` symlink so the git submodule worktree path (`.git/modules/tsumugi/config` has `worktree = ../../../aspects/tsumugi`) resolves correctly inside the container
- **docker-compose.yml**: Mount parent repo's `.git/modules/tsumugi` for submodule `.git` reference resolution; add `claude_config` named volume for persistent Claude config

## Test Plan
- [ ] Rebuild devcontainer and verify `git status` works without submodule errors
- [ ] Verify Claude config persists across container restarts
- [ ] Verify git operations (commit, push, pull) work correctly

Generated with Claude Code