### PR TITLE
feat: 自分のプロパティ一覧API実装 (GET /api/properties/my)

### DIFF
--- a/src/app/api/properties/my/__tests__/route.test.ts
+++ b/src/app/api/properties/my/__tests__/route.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockSelect = vi.fn();
+const mockFrom = vi.fn();
+const mockWhere = vi.fn();
+const mockOrderBy = vi.fn();
+
+vi.mock('@/lib/auth', () => ({
+  auth: { api: { getSession: vi.fn() } },
+}));
+
+vi.mock('@/db', () => ({
+  db: {
+    select: mockSelect,
+  },
+}));
+
+vi.mock('@/db/schema', () => ({
+  properties: { userId: 'userId', createdAt: 'createdAt' },
+}));
+
+describe('GET /api/properties/my', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockOrderBy.mockResolvedValue([]);
+    mockWhere.mockReturnValue({ orderBy: mockOrderBy });
+    mockFrom.mockReturnValue({ where: mockWhere });
+    mockSelect.mockReturnValue({ from: mockFrom });
+  });
+
+  it('returns 401 if not authenticated', async () => {
+    const { GET } = await import('../route');
+    const { auth } = await import('@/lib/auth');
+    vi.mocked(auth.api.getSession).mockResolvedValue(null as any);
+
+    const req = new Request('http://localhost/api/properties/my');
+    const res = await GET(req);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns user properties including drafts', async () => {
+    const { GET } = await import('../route');
+    const { auth } = await import('@/lib/auth');
+    vi.mocked(auth.api.getSession).mockResolvedValue({
+      session: { id: 's1', userId: 'u1' },
+      user: { id: 'u1' },
+    } as any);
+
+    mockOrderBy.mockResolvedValue([
+      { id: '1', title: 'My Property', status: 'draft' },
+      { id: '2', title: 'Published', status: 'public' },
+    ]);
+
+    const req = new Request('http://localhost/api/properties/my');
+    const res = await GET(req);
+    const body = (await res.json()) as { data: { status: string }[] };
+
+    expect(res.status).toBe(200);
+    expect(body.data).toHaveLength(2);
+    expect(body.data[0].status).toBe('draft');
+  });
+
+  it('returns 500 on error', async () => {
+    const { GET } = await import('../route');
+    const { auth } = await import('@/lib/auth');
+    vi.mocked(auth.api.getSession).mockResolvedValue({
+      session: { id: 's1', userId: 'u1' },
+      user: { id: 'u1' },
+    } as any);
+
+    mockSelect.mockImplementation(() => {
+      throw new Error('DB error');
+    });
+
+    const req = new Request('http://localhost/api/properties/my');
+    const res = await GET(req);
+    expect(res.status).toBe(500);
+  });
+});

--- a/src/app/api/properties/my/route.ts
+++ b/src/app/api/properties/my/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from 'next/server';
+import { eq, desc } from 'drizzle-orm';
+import { auth } from '@/lib/auth';
+import { db } from '@/db';
+import { properties } from '@/db/schema';
+
+/**
+ * GET /api/properties/my
+ *
+ * ログインユーザーの物件一覧を取得（draft含む）。
+ * 作成日時降順でソート。
+ */
+export async function GET(request: Request) {
+  try {
+    const session = await auth.api.getSession({
+      headers: request.headers,
+    });
+
+    if (!session?.user?.id) {
+      return NextResponse.json(
+        { error: 'ログインが必要です' },
+        { status: 401 }
+      );
+    }
+
+    const items = await db
+      .select()
+      .from(properties)
+      .where(eq(properties.userId, session.user.id))
+      .orderBy(desc(properties.createdAt));
+
+    return NextResponse.json({ data: items });
+  } catch (error) {
+    console.error('Failed to fetch user properties:', error);
+    return NextResponse.json(
+      { error: 'プロパティの取得に失敗しました' },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- ログインユーザーが自分の物件一覧を取得するAPIエンドポイントを実装
- 認証済みユーザーのみアクセス可能、draft含む全物件を作成日時降順で返す
- ユニットテスト3件（認証エラー、正常取得、サーバーエラー）

## Changes
- `src/app/api/properties/my/route.ts` - GET /api/properties/my エンドポイント新規作成
- `src/app/api/properties/my/__tests__/route.test.ts` - ユニットテスト追加

## Test Plan
- [ ] 未認証ユーザーが401を受け取ることを確認
- [ ] 認証ユーザーがdraft含む物件一覧を取得できることを確認
- [ ] DBエラー時に500が返ることを確認

Generated with Claude Code