### PR TITLE
feat: プロパティ一覧取得API実装 (GET /api/properties)

### DIFF
--- a/src/app/api/properties/__tests__/get-route.test.ts
+++ b/src/app/api/properties/__tests__/get-route.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockSelect = vi.fn();
+const mockFrom = vi.fn();
+const mockWhere = vi.fn();
+const mockOrderBy = vi.fn();
+const mockLimit = vi.fn();
+const mockOffset = vi.fn();
+
+vi.mock('@/lib/auth', () => ({
+  auth: { api: { getSession: vi.fn() } },
+}));
+
+vi.mock('@/db', () => ({
+  db: {
+    insert: vi.fn(() => ({
+      values: vi.fn(() => ({ returning: vi.fn() })),
+    })),
+    select: mockSelect,
+  },
+}));
+
+vi.mock('@/db/schema', () => ({
+  properties: { status: 'status', createdAt: 'createdAt' },
+}));
+
+describe('GET /api/properties', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Chain: select() -> from() -> where() -> orderBy() -> limit() -> offset()
+    mockOffset.mockResolvedValue([
+      { id: '1', title: 'Test Property', status: 'public' },
+    ]);
+    mockLimit.mockReturnValue({ offset: mockOffset });
+    mockOrderBy.mockReturnValue({ limit: mockLimit });
+    mockWhere.mockReturnValue({ orderBy: mockOrderBy });
+    mockFrom.mockReturnValue({ where: mockWhere });
+    mockSelect.mockReturnValue({ from: mockFrom });
+  });
+
+  it('returns public properties with pagination', async () => {
+    // Mock count query (second call to select)
+    let callCount = 0;
+    mockSelect.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        // Data query
+        return { from: mockFrom };
+      }
+      // Count query
+      return {
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([{ count: 1 }]),
+        }),
+      };
+    });
+
+    const { GET } = await import('../route');
+    const req = new Request('http://localhost/api/properties');
+    const res = await GET(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toHaveProperty('data');
+    expect(body).toHaveProperty('pagination');
+    expect(body.pagination).toHaveProperty('page', 1);
+    expect(body.pagination).toHaveProperty('limit', 20);
+  });
+
+  it('respects page and limit params', async () => {
+    let callCount = 0;
+    mockSelect.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        return { from: mockFrom };
+      }
+      return {
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([{ count: 50 }]),
+        }),
+      };
+    });
+
+    const { GET } = await import('../route');
+    const req = new Request('http://localhost/api/properties?page=2&limit=10');
+    const res = await GET(req);
+    const body = await res.json();
+
+    expect(body.pagination.page).toBe(2);
+    expect(body.pagination.limit).toBe(10);
+    expect(body.pagination.totalPages).toBe(5);
+  });
+
+  it('returns 500 on error', async () => {
+    mockSelect.mockImplementation(() => {
+      throw new Error('DB error');
+    });
+
+    const { GET } = await import('../route');
+    const req = new Request('http://localhost/api/properties');
+    const res = await GET(req);
+
+    expect(res.status).toBe(500);
+  });
+});

--- a/src/app/api/properties/route.ts
+++ b/src/app/api/properties/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { eq, desc, sql } from 'drizzle-orm';
 import { randomUUID } from 'crypto';
 import zod from 'zod';
 const z = zod;
@@ -141,6 +142,50 @@ export async function POST(request: Request) {
     }
     return NextResponse.json(
       { error: 'プロパティの作成に失敗しました' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function GET(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const page = Math.max(1, parseInt(searchParams.get('page') || '1', 10));
+    const limit = Math.min(
+      100,
+      Math.max(1, parseInt(searchParams.get('limit') || '20', 10))
+    );
+    const offset = (page - 1) * limit;
+
+    const [items, countResult] = await Promise.all([
+      db
+        .select()
+        .from(properties)
+        .where(eq(properties.status, 'public'))
+        .orderBy(desc(properties.createdAt))
+        .limit(limit)
+        .offset(offset),
+      db
+        .select({ count: sql<number>`count(*)` })
+        .from(properties)
+        .where(eq(properties.status, 'public')),
+    ]);
+
+    const total = Number(countResult[0]?.count ?? 0);
+
+    return NextResponse.json({
+      data: items,
+      pagination: {
+        page,
+        limit,
+        total,
+        totalPages: Math.ceil(total / limit),
+      },
+    });
+  } catch (error) {
+    console.error('Failed to fetch properties:', error);
+    return NextResponse.json(
+      { error: 'プロパティの取得に失敗しました' },
       { status: 500 }
     );
   }


### PR DESCRIPTION
タスク tsumugi-p2y: プロパティ一覧取得API実装

- GET /api/properties エンドポイント新規作成
- ページネーション対応（limit, offset）
- 公開中物件のみ返却
- テスト3件追加