### PR TITLE
feat: add Stripe Connect onboarding for hosts

### DIFF
--- a/src/app/account/page.tsx
+++ b/src/app/account/page.tsx
@@ -18,6 +18,7 @@ import {
   Sparkles,
   ChevronRight,
   Edit,
+  CreditCard,
 } from 'lucide-react';
 
 export default function AccountPage() {
@@ -208,6 +209,29 @@ export default function AccountPage() {
                 </div>
               </div>
             </div>
+          )}
+
+          {/* Stripe Connect設定（ホストのみ） */}
+          {user.isSeller && (
+            <Link
+              href="/account/stripe-setup"
+              className="mb-6 flex items-center justify-between rounded-xl border border-border bg-background p-6 shadow-sm transition-shadow hover:shadow-md"
+            >
+              <div className="flex items-center gap-4">
+                <div className="rounded-full bg-green-100 dark:bg-green-950 p-3">
+                  <CreditCard className="h-6 w-6 text-green-600 dark:text-green-500" />
+                </div>
+                <div>
+                  <p className="font-semibold text-foreground">
+                    報酬受取口座の設定
+                  </p>
+                  <p className="text-sm text-muted-foreground">
+                    Stripe Connectで報酬の受取口座を設定
+                  </p>
+                </div>
+              </div>
+              <ChevronRight className="h-5 w-5 text-muted-foreground" />
+            </Link>
           )}
 
           {/* 前の住人になる（非ホストのみ） */}

--- a/src/app/account/stripe-setup/page.tsx
+++ b/src/app/account/stripe-setup/page.tsx
@@ -1,0 +1,137 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import Link from 'next/link';
+import { ArrowLeft, CheckCircle2, RefreshCw } from 'lucide-react';
+import { Header } from '@/components/header';
+import { Footer } from '@/components/footer';
+import { useAuth } from '@/contexts/auth-context';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { StripeConnectOnboarding } from '@/components/payment/stripe-connect-onboarding';
+
+export default function StripeSetupPage() {
+  const { user, isLoading } = useAuth();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const callbackStatus = searchParams.get('status');
+
+  useEffect(() => {
+    if (!isLoading && !user) {
+      router.push('/');
+    }
+  }, [user, isLoading, router]);
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-screen flex-col">
+        <Header />
+        <main className="flex-1 flex items-center justify-center">
+          <div className="animate-pulse text-muted-foreground">
+            読み込み中...
+          </div>
+        </main>
+        <Footer />
+      </div>
+    );
+  }
+
+  if (!user) {
+    return null;
+  }
+
+  return (
+    <div className="flex min-h-screen flex-col">
+      <Header />
+
+      <main className="flex-1 bg-muted/30">
+        <div className="mx-auto max-w-2xl px-6 py-12">
+          <Link
+            href="/account"
+            className="mb-6 inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            アカウントに戻る
+          </Link>
+
+          <h1 className="mb-2 text-2xl font-semibold text-foreground">
+            報酬受取口座の設定
+          </h1>
+          <p className="mb-8 text-muted-foreground">
+            引き継ぎの報酬を受け取るための口座を設定します
+          </p>
+
+          {/* Callback status messages */}
+          {callbackStatus === 'complete' && (
+            <Card className="mb-6 border-green-200 dark:border-green-800">
+              <CardContent className="pt-6">
+                <div className="flex items-start gap-3">
+                  <CheckCircle2 className="mt-0.5 h-5 w-5 flex-shrink-0 text-green-600 dark:text-green-500" />
+                  <div>
+                    <p className="font-semibold text-green-900 dark:text-green-100">
+                      設定が完了しました
+                    </p>
+                    <p className="mt-1 text-sm text-green-800 dark:text-green-200">
+                      Stripeでの口座設定が完了しました。下記のステータスをご確認ください。
+                    </p>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          )}
+
+          {callbackStatus === 'refresh' && (
+            <Card className="mb-6 border-yellow-200 dark:border-yellow-800">
+              <CardContent className="pt-6">
+                <div className="flex items-start gap-3">
+                  <RefreshCw className="mt-0.5 h-5 w-5 flex-shrink-0 text-yellow-600 dark:text-yellow-500" />
+                  <div>
+                    <p className="font-semibold text-yellow-900 dark:text-yellow-100">
+                      設定を続けてください
+                    </p>
+                    <p className="mt-1 text-sm text-yellow-800 dark:text-yellow-200">
+                      Stripeでの設定が中断されました。下のボタンから設定を続けてください。
+                    </p>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          )}
+
+          {/* Onboarding component */}
+          <StripeConnectOnboarding userId={user.id} userEmail={user.email} />
+
+          {/* Info section */}
+          <Card className="mt-6">
+            <CardHeader>
+              <CardTitle className="text-base">よくあるご質問</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4 text-sm">
+              <div>
+                <p className="font-medium">報酬はいつ受け取れますか？</p>
+                <p className="mt-1 text-muted-foreground">
+                  引き継ぎが完了し、双方が確認した後、エスクローから口座に送金されます。通常2〜3営業日でお振込みされます。
+                </p>
+              </div>
+              <div>
+                <p className="font-medium">手数料はかかりますか？</p>
+                <p className="mt-1 text-muted-foreground">
+                  口座の設定は無料です。引き継ぎ時にプラットフォーム手数料（15%）が差し引かれます。
+                </p>
+              </div>
+              <div>
+                <p className="font-medium">個人情報は安全ですか？</p>
+                <p className="mt-1 text-muted-foreground">
+                  口座情報はStripe（国際決済プラットフォーム）が安全に管理します。tsumugiでは口座情報を直接保持しません。
+                </p>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </main>
+
+      <Footer />
+    </div>
+  );
+}

--- a/src/components/payment/stripe-connect-onboarding.tsx
+++ b/src/components/payment/stripe-connect-onboarding.tsx
@@ -1,0 +1,261 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { Loader2, CheckCircle2, AlertCircle, ExternalLink } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  createConnectAccount,
+  getConnectAccountOnboardingLink,
+  getConnectAccountStatus,
+} from '@/app/actions/stripe-connect';
+
+type AccountStatus = {
+  exists: boolean;
+  account?: {
+    stripeAccountId: string;
+    onboardingCompleted: boolean;
+    chargesEnabled: boolean;
+    payoutsEnabled: boolean;
+  };
+};
+
+interface StripeConnectOnboardingProps {
+  userId: string;
+  userEmail: string;
+}
+
+export function StripeConnectOnboarding({
+  userId,
+  userEmail,
+}: StripeConnectOnboardingProps) {
+  const [status, setStatus] = useState<AccountStatus | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isCreating, setIsCreating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchStatus = useCallback(async () => {
+    try {
+      const result = await getConnectAccountStatus(userId);
+      if (!result.success) {
+        throw new Error(result.error || 'ステータスの取得に失敗しました');
+      }
+      setStatus({
+        exists: result.exists ?? false,
+        account: result.account,
+      });
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : 'ステータスの取得に失敗しました'
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  }, [userId]);
+
+  useEffect(() => {
+    fetchStatus();
+  }, [fetchStatus]);
+
+  const handleStartOnboarding = async () => {
+    setIsCreating(true);
+    setError(null);
+
+    try {
+      // Step 1: Create the account if it doesn't exist
+      let accountId = status?.account?.stripeAccountId;
+
+      if (!accountId) {
+        const createResult = await createConnectAccount(
+          userId,
+          'previous_tenant',
+          userEmail
+        );
+        if (!createResult.success) {
+          throw new Error(createResult.error || 'アカウント作成に失敗しました');
+        }
+        accountId = createResult.accountId;
+      }
+
+      if (!accountId) {
+        throw new Error('アカウントIDの取得に失敗しました');
+      }
+
+      // Step 2: Get onboarding link
+      const returnUrl = `${window.location.origin}/account/stripe-setup?status=complete`;
+      const refreshUrl = `${window.location.origin}/account/stripe-setup?status=refresh`;
+
+      const linkResult = await getConnectAccountOnboardingLink(
+        accountId,
+        returnUrl,
+        refreshUrl
+      );
+
+      if (!linkResult.success || !linkResult.url) {
+        throw new Error(
+          linkResult.error || 'オンボーディングリンクの取得に失敗しました'
+        );
+      }
+
+      // Step 3: Redirect to Stripe
+      window.location.href = linkResult.url;
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : '処理中にエラーが発生しました'
+      );
+      setIsCreating(false);
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>報酬受取口座</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex items-center justify-center py-8">
+            <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+            <span className="ml-3 text-muted-foreground">読み込み中...</span>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // Account fully set up
+  if (status?.account?.chargesEnabled && status?.account?.payoutsEnabled) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>報酬受取口座</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex items-start gap-3 rounded-lg border border-green-200 bg-green-50 p-4 dark:border-green-800 dark:bg-green-950/30">
+            <CheckCircle2 className="mt-0.5 h-5 w-5 flex-shrink-0 text-green-600 dark:text-green-500" />
+            <div>
+              <p className="font-semibold text-green-900 dark:text-green-100">
+                口座設定済み
+              </p>
+              <p className="mt-1 text-sm text-green-800 dark:text-green-200">
+                報酬受取口座が正常に設定されています。引き継ぎが完了すると、設定した口座に報酬が送金されます。
+              </p>
+            </div>
+          </div>
+
+          <div className="mt-4 space-y-2 text-sm">
+            <div className="flex items-center gap-2">
+              <CheckCircle2 className="h-4 w-4 text-green-600" />
+              <span>本人確認完了</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <CheckCircle2 className="h-4 w-4 text-green-600" />
+              <span>入金受付有効</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <CheckCircle2 className="h-4 w-4 text-green-600" />
+              <span>出金有効</span>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // Account exists but onboarding incomplete
+  if (status?.exists && status?.account) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>報酬受取口座</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex items-start gap-3 rounded-lg border border-yellow-200 bg-yellow-50 p-4 dark:border-yellow-800 dark:bg-yellow-950/30">
+            <AlertCircle className="mt-0.5 h-5 w-5 flex-shrink-0 text-yellow-600 dark:text-yellow-500" />
+            <div>
+              <p className="font-semibold text-yellow-900 dark:text-yellow-100">
+                設定が未完了です
+              </p>
+              <p className="mt-1 text-sm text-yellow-800 dark:text-yellow-200">
+                Stripeでの本人確認が完了していません。オンボーディングを続けて設定を完了してください。
+              </p>
+            </div>
+          </div>
+
+          {error && (
+            <div className="mt-4 rounded-lg border border-red-200 bg-red-50 p-4 dark:border-red-800 dark:bg-red-950/30">
+              <p className="text-sm text-red-800 dark:text-red-200">{error}</p>
+            </div>
+          )}
+
+          <Button
+            onClick={handleStartOnboarding}
+            disabled={isCreating}
+            className="mt-4 w-full"
+            size="lg"
+          >
+            {isCreating ? (
+              <>
+                <Loader2 className="h-5 w-5 animate-spin" />
+                <span>準備中...</span>
+              </>
+            ) : (
+              <>
+                <ExternalLink className="h-5 w-5" />
+                <span>設定を続ける</span>
+              </>
+            )}
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // No account yet
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>報酬受取口座</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <p className="mb-4 text-sm text-muted-foreground">
+          引き継ぎの報酬を受け取るには、Stripeで口座情報を登録する必要があります。本人確認と銀行口座の登録を行ってください。
+        </p>
+
+        <div className="mb-4 space-y-2 rounded-lg bg-muted/50 p-4 text-sm">
+          <p className="font-medium">設定に必要なもの：</p>
+          <ul className="ml-4 list-disc space-y-1 text-muted-foreground">
+            <li>本人確認書類（免許証、パスポートなど）</li>
+            <li>銀行口座情報</li>
+          </ul>
+        </div>
+
+        {error && (
+          <div className="mb-4 rounded-lg border border-red-200 bg-red-50 p-4 dark:border-red-800 dark:bg-red-950/30">
+            <p className="text-sm text-red-800 dark:text-red-200">{error}</p>
+          </div>
+        )}
+
+        <Button
+          onClick={handleStartOnboarding}
+          disabled={isCreating}
+          className="w-full"
+          size="lg"
+        >
+          {isCreating ? (
+            <>
+              <Loader2 className="h-5 w-5 animate-spin" />
+              <span>準備中...</span>
+            </>
+          ) : (
+            '報酬受取口座を設定'
+          )}
+        </Button>
+
+        <p className="mt-3 text-center text-xs text-muted-foreground">
+          Stripeの安全な環境で口座情報を登録します
+        </p>
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary
- Add Stripe Connect onboarding flow so hosts can set up payout accounts
- New dedicated setup page at /account/stripe-setup
- Add navigation link from account page for seller users

## Changes
- `src/components/payment/stripe-connect-onboarding.tsx`: Onboarding wizard component with account creation, OAuth flow, and status display
- `src/app/account/stripe-setup/page.tsx`: Stripe setup page with header and onboarding component
- `src/app/account/page.tsx`: Add CreditCard icon import and "報酬受取口座の設定" link for sellers

## Test Plan
- [ ] Verify account page shows Stripe setup link for seller users
- [ ] Verify non-seller users don't see the link
- [ ] Navigate to /account/stripe-setup - verify onboarding component loads
- [ ] Test Stripe Connect account creation flow

Generated with Claude Code