### PR TITLE
feat: display star ratings on property cards and review list

### DIFF
--- a/src/app/listings/[id]/page.tsx
+++ b/src/app/listings/[id]/page.tsx
@@ -28,6 +28,8 @@ import {
 import { isUrgentMoveIn } from '@/lib/utils';
 import { UrgentMoveInBadge } from '@/components/urgent-move-in-badge';
 import { ConsentBadge } from '@/components/consent-badge';
+import { ReviewList } from '@/components/review-list';
+import { getPropertyReviews, getPropertyRating } from '@/lib/review-data';
 
 const FURNITURE_ICONS: Record<string, typeof BedDouble> = {
   bed: BedDouble,
@@ -71,6 +73,8 @@ export default async function PropertyDetailPage({
 }: PropertyDetailPageProps) {
   const { id } = await params;
   const property = getPropertyById(id);
+  const propertyReviews = getPropertyReviews(id);
+  const propertyRating = getPropertyRating(id);
 
   if (!property || property.status !== 'public') {
     notFound();
@@ -269,6 +273,16 @@ export default async function PropertyDetailPage({
                   lng={property.location.lng}
                   neighborhood={property.location.neighborhood}
                   title={property.title}
+                />
+              </div>
+            )}
+
+            {/* Reviews Section */}
+            {propertyReviews.length > 0 && (
+              <div className="lg:col-span-5 pt-8 border-t border-border">
+                <ReviewList
+                  reviews={propertyReviews}
+                  aggregate={propertyRating}
                 />
               </div>
             )}

--- a/src/components/property-card.tsx
+++ b/src/components/property-card.tsx
@@ -10,6 +10,8 @@ import type { Property } from '@/lib/data';
 import { isUrgentMoveIn } from '@/lib/utils';
 import { UrgentMoveInBadge } from '@/components/urgent-move-in-badge';
 import { ConsentBadge } from '@/components/consent-badge';
+import { StarRating } from '@/components/ui/star-rating';
+import { getPropertyRating } from '@/lib/review-data';
 
 function parseLocation(neighborhood: string | undefined): {
   ward?: string;
@@ -31,6 +33,7 @@ export function PropertyCard({ property }: PropertyCardProps) {
   const [currentImage, setCurrentImage] = useState(0);
   const [isLiked, setIsLiked] = useState(false);
   const [imageLoaded, setImageLoaded] = useState(false);
+  const rating = getPropertyRating(property.id);
 
   const nextImage = (e: React.MouseEvent) => {
     e.preventDefault();
@@ -136,6 +139,17 @@ export function PropertyCard({ property }: PropertyCardProps) {
         <h3 className="font-medium text-foreground line-clamp-1">
           {property.title}
         </h3>
+
+        {rating.reviewCount > 0 && (
+          <div className="mt-1">
+            <StarRating
+              value={rating.averageRating}
+              size={14}
+              showValue
+              reviewCount={rating.reviewCount}
+            />
+          </div>
+        )}
 
         <p className="mt-1.5 text-sm">
           <span className="text-muted-foreground">引き継ぎ費用 </span>

--- a/src/components/review-list.tsx
+++ b/src/components/review-list.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { StarRating } from '@/components/ui/star-rating';
+import type { ReviewWithReviewer, RatingAggregate } from '@/lib/review-types';
+
+interface ReviewListProps {
+  reviews: ReviewWithReviewer[];
+  aggregate: RatingAggregate;
+}
+
+export function ReviewList({ reviews, aggregate }: ReviewListProps) {
+  if (reviews.length === 0) return null;
+
+  return (
+    <section>
+      <div className="flex items-center gap-3 mb-6">
+        <h2 className="text-xl font-semibold text-foreground">レビュー</h2>
+        <StarRating
+          value={aggregate.averageRating}
+          size={18}
+          showValue
+          reviewCount={aggregate.reviewCount}
+        />
+      </div>
+
+      <div className="space-y-6">
+        {reviews.map((review) => (
+          <div
+            key={review.id}
+            className="border-b border-border pb-6 last:border-0"
+          >
+            <div className="flex items-center justify-between mb-2">
+              <div className="flex items-center gap-2">
+                <div className="h-8 w-8 rounded-full bg-muted flex items-center justify-center text-xs font-medium text-muted-foreground">
+                  {review.reviewerName.charAt(0)}
+                </div>
+                <span className="text-sm font-medium text-foreground">
+                  {review.reviewerName}
+                </span>
+              </div>
+              <time className="text-xs text-muted-foreground">
+                {new Date(review.createdAt).toLocaleDateString('ja-JP', {
+                  year: 'numeric',
+                  month: 'long',
+                })}
+              </time>
+            </div>
+            <div className="mb-2">
+              <StarRating value={review.rating} size={14} />
+            </div>
+            {review.comment && (
+              <p className="text-sm text-foreground leading-relaxed">
+                {review.comment}
+              </p>
+            )}
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- Add star rating display (average + review count) to property cards in the listing grid
- Create `ReviewList` component showing individual reviews with ratings, comments, and dates
- Integrate review section into property detail page (after the location/map section)

## Files Changed
- `src/components/property-card.tsx` - Added StarRating import and display below property title
- `src/components/review-list.tsx` - New component for rendering review list with aggregate rating
- `src/app/listings/[id]/page.tsx` - Added review section to property detail page

## Test plan
- [x] All 440 tests passing locally (no new tests needed - uses existing StarRating + review-data tests)
- [ ] CI passes (lint + unit tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)