### PR TITLE
ci: add required ci status check to e2e workflow

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -458,3 +458,17 @@ jobs:
               repo: context.repo.repo,
               body: comment
             });
+
+  # Aggregate status check required by branch protection
+  ci:
+    runs-on: ubuntu-latest
+    if: always()
+    needs: [determine-tests, e2e-tests]
+    steps:
+      - name: Check results
+        run: |
+          if [[ "${{ needs.e2e-tests.result }}" == "failure" ]]; then
+            echo "E2E tests failed"
+            exit 1
+          fi
+          echo "CI passed"


### PR DESCRIPTION
## Summary
- Add aggregate `ci` job to the E2E Tests workflow that branch protection requires
- Without this, no PRs can be merged because the required `ci` check is never reported

## Changes
- `.github/workflows/e2e-tests.yml`: Add `ci` job that depends on `determine-tests` and `e2e-tests`, reports failure only if e2e-tests explicitly fails (skipped is OK)

## Test Plan
- [ ] Verify `ci` status check appears on this PR
- [ ] Verify PR becomes mergeable after ci check passes
- [ ] Verify all 9 pending PRs (#271-#279) can be merged after this lands

Generated with Claude Code