### PR TITLE
feat: mock data environment toggle and remove localStorage

### DIFF
--- a/src/contexts/auth-context.tsx
+++ b/src/contexts/auth-context.tsx
@@ -40,14 +40,11 @@ interface AuthContextType {
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
-const LISTINGS_STORAGE_KEY = 'tsumugi_listings';
-const INQUIRIES_STORAGE_KEY = 'tsumugi_inquiries';
-
 export function AuthProvider({ children }: { children: ReactNode }) {
   // better-auth session
   const { data: session, isPending: sessionLoading } = authClient.useSession();
 
-  // Local state for listings and inquiries (Phase 1: localStorage)
+  // Local state for listings and inquiries (dev: mock data, prod: empty - use APIs)
   const [listings, setListings] = useState<UserListing[]>([]);
   const [inquiries, setInquiries] = useState<Inquiry[]>([]);
   const [isInitialized, setIsInitialized] = useState(false);
@@ -69,77 +66,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const isLoading = sessionLoading || !isInitialized;
 
-  // Initialize listings and inquiries from localStorage
+  // Initialize mock data in development only (no localStorage)
   useEffect(() => {
-    if (typeof window === 'undefined') {
-      setIsInitialized(true);
-      return;
-    }
-
-    // Load mock inquiries in development
     if (process.env.NODE_ENV === 'development') {
       setInquiries(mockInquiries);
-    } else {
-      // Load from localStorage in production
-      const storedInquiries = localStorage.getItem(INQUIRIES_STORAGE_KEY);
-      if (storedInquiries) {
-        try {
-          setInquiries(JSON.parse(storedInquiries) as Inquiry[]);
-        } catch {
-          localStorage.removeItem(INQUIRIES_STORAGE_KEY);
-        }
-      }
     }
-
-    // Load listings from localStorage
-    const storedListings = localStorage.getItem(LISTINGS_STORAGE_KEY);
-    if (storedListings) {
-      try {
-        setListings(JSON.parse(storedListings) as UserListing[]);
-      } catch {
-        localStorage.removeItem(LISTINGS_STORAGE_KEY);
-      }
-    }
-
     setIsInitialized(true);
   }, []);
-
-  // Persist listings to localStorage
-  useEffect(() => {
-    if (typeof window === 'undefined' || !isInitialized) return;
-    try {
-      localStorage.setItem(LISTINGS_STORAGE_KEY, JSON.stringify(listings));
-    } catch (e) {
-      console.warn('Failed to save listings with photos, trying without:', e);
-      try {
-        const listingsWithoutPhotos = listings.map((listing) => ({
-          ...listing,
-          roomPhotos: [],
-        }));
-        localStorage.setItem(
-          LISTINGS_STORAGE_KEY,
-          JSON.stringify(listingsWithoutPhotos)
-        );
-      } catch (e2) {
-        console.error('Failed to save listings to localStorage:', e2);
-      }
-    }
-  }, [listings, isInitialized]);
-
-  // Persist inquiries to localStorage
-  useEffect(() => {
-    if (
-      typeof window === 'undefined' ||
-      !isInitialized ||
-      process.env.NODE_ENV === 'development'
-    )
-      return;
-    try {
-      localStorage.setItem(INQUIRIES_STORAGE_KEY, JSON.stringify(inquiries));
-    } catch (e) {
-      console.error('Failed to save inquiries to localStorage:', e);
-    }
-  }, [inquiries, isInitialized]);
 
   // Send magic link
   const sendMagicLink = useCallback(

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -2821,11 +2821,21 @@ export function convertUserListingToProperty(listing: UserListing): Property {
   };
 }
 
+/**
+ * Returns mock data only in development. In production, returns empty
+ * so that callers fall through to real API/database queries.
+ */
+function isMockEnabled(): boolean {
+  return process.env.NODE_ENV === 'development';
+}
+
 export function getPublicProperties(): Property[] {
+  if (!isMockEnabled()) return [];
   return properties.filter((p) => p.status === 'public');
 }
 
 export function getPropertyById(id: string): Property | undefined {
+  if (!isMockEnabled()) return undefined;
   return properties.find((p) => p.id === id);
 }
 
@@ -3016,6 +3026,7 @@ export const mockHandoverAgreements: HandoverAgreement[] = [
 
 // Inquiry functions
 export function getAllInquiries(): Inquiry[] {
+  if (!isMockEnabled()) return [];
   return inquiries.sort(
     (a, b) =>
       new Date(b.submittedAt).getTime() - new Date(a.submittedAt).getTime()
@@ -3023,6 +3034,7 @@ export function getAllInquiries(): Inquiry[] {
 }
 
 export function getInquiriesByProperty(propertyId: string): Inquiry[] {
+  if (!isMockEnabled()) return [];
   return inquiries
     .filter((inq) => inq.propertyId === propertyId)
     .sort(
@@ -3032,11 +3044,13 @@ export function getInquiriesByProperty(propertyId: string): Inquiry[] {
 }
 
 export function getInquiryById(id: string): Inquiry | undefined {
+  if (!isMockEnabled()) return undefined;
   return inquiries.find((inq) => inq.id === id);
 }
 
 // Seller Listing functions
 export function getAllSellerListings(): SellerListing[] {
+  if (!isMockEnabled()) return [];
   return hostListings.sort(
     (a, b) =>
       new Date(b.submittedAt).getTime() - new Date(a.submittedAt).getTime()
@@ -3044,5 +3058,6 @@ export function getAllSellerListings(): SellerListing[] {
 }
 
 export function getSellerListingById(id: string): SellerListing | undefined {
+  if (!isMockEnabled()) return undefined;
   return hostListings.find((listing) => listing.id === id);
 }


### PR DESCRIPTION
## Summary
- **TSU-205**: Add `isMockEnabled()` to `data.ts` - mock data only returned in development
- **TSU-206**: Remove all localStorage persistence from `auth-context.tsx`

## Changes
- `src/lib/data.ts`: Add `isMockEnabled()` guard to `getPublicProperties()`, `getPropertyById()`, `getAllInquiries()`, `getInquiriesByProperty()`, `getInquiryById()`, `getAllSellerListings()`, `getSellerListingById()`
- `src/contexts/auth-context.tsx`: Remove `LISTINGS_STORAGE_KEY`, `INQUIRIES_STORAGE_KEY`, all localStorage read/write, and localStorage persistence effects

## Test Plan
- [ ] Dev mode: mock data still loads on pages
- [ ] No localStorage keys written in dev mode
- [ ] Verify auth-context still provides user session via Better Auth

Generated with Claude Code