### PR TITLE
test: 認証フローE2Eテスト追加 (TSU-114)

### DIFF
--- a/tests/e2e/auth/authentication.spec.ts
+++ b/tests/e2e/auth/authentication.spec.ts
@@ -215,6 +215,59 @@ test.describe('Authentication - Logout Flow @auth @critical', () => {
   });
 });
 
+test.describe('Authentication - Protected Routes @auth @critical', () => {
+  test('should redirect to home when visiting /listing without auth', async ({
+    page,
+  }) => {
+    await clearLocalStorage(page);
+    await page.goto('/listing');
+    await page.waitForURL('/', { timeout: 5000 });
+    expect(page.url()).toContain('/');
+  });
+
+  test('should redirect to home when visiting /account without auth', async ({
+    page,
+  }) => {
+    await clearLocalStorage(page);
+    await page.goto('/account');
+    await page.waitForURL('/', { timeout: 5000 });
+    expect(page.url()).toContain('/');
+  });
+});
+
+test.describe('Authentication - Session Persistence @auth @critical', () => {
+  test('should maintain auth state after page navigation', async ({ page }) => {
+    await page.goto('/');
+    await setupAuthenticatedUser(page);
+
+    // Navigate to a different page
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    // User should still be logged in
+    const userState = await page.evaluate(() => {
+      return localStorage.getItem('tsumugi_user');
+    });
+    expect(userState).not.toBeNull();
+  });
+
+  test('should maintain auth state after browser reload', async ({ page }) => {
+    await page.goto('/');
+    await setupAuthenticatedUser(page);
+
+    // Reload
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(500);
+
+    // User should still be logged in
+    const userState = await page.evaluate(() => {
+      return localStorage.getItem('tsumugi_user');
+    });
+    expect(userState).not.toBeNull();
+  });
+});
+
 test.describe('Authentication - Become Seller Flow @auth @listing @quarantine', () => {
   test('should trigger login dialog when clicking "暮らしを譲る" while not logged in', async ({
     authPage,


### PR DESCRIPTION
## Summary

- Add E2E tests for authentication protected routes and session persistence
- Protected routes: `/listing` and `/account` redirect to `/` when not authenticated
- Session persistence: auth state maintained after page navigation and browser reload
- 4 new test cases added to `tests/e2e/auth/authentication.spec.ts`

## Test plan

- [ ] CI passes (lint, types, unit tests, E2E)
- [ ] Protected route tests verify redirect behavior
- [ ] Session persistence tests verify localStorage state

Closes TSU-114

🤖 Generated with [Claude Code](https://claude.com/claude-code)