### PR TITLE
chore: add Claude Code tool permissions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,14 @@
 {
   "permissions": {
-    "allow": ["mcp__*", "Bash(*)"]
+    "allow": [
+      "mcp__*",
+      "Bash(*)",
+      "Read",
+      "Edit",
+      "Write",
+      "WebFetch",
+      "WebSearch"
+    ]
   },
   "enableAllProjectMcpServers": true,
   "enabledPlugins": {


### PR DESCRIPTION
## Summary
- Added `Read`, `Edit`, `Write`, `WebFetch`, `WebSearch` to the Claude Code permissions allow list
- Reduces confirmation prompts for core tool operations during development

## Changes
- `.claude/settings.json`: Expanded `permissions.allow` array with 5 additional tool entries

## Test Plan
- [x] JSON is valid
- [x] Pre-existing CI issues only (no new issues introduced)
- [ ] Verify Claude Code sessions use new permissions without prompts

Generated with Claude Code