### PR TITLE
feat: allow outbound HTTP/HTTPS in devcontainer firewall

### DIFF
--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -140,11 +140,12 @@ iptables -A OUTPUT -j REJECT --reject-with icmp-admin-prohibited
 
 echo "Firewall configuration complete"
 echo "Verifying firewall rules..."
-if curl --connect-timeout 5 https://example.com >/dev/null 2>&1; then
-    echo "ERROR: Firewall verification failed - was able to reach https://example.com"
+# HTTP/HTTPS are intentionally open; verify non-HTTP traffic to unlisted hosts is blocked
+if nc -z -w 5 example.com 9999 2>/dev/null; then
+    echo "ERROR: Firewall verification failed - was able to reach example.com:9999"
     exit 1
 else
-    echo "Firewall verification passed - unable to reach https://example.com as expected"
+    echo "Firewall verification passed - non-HTTP traffic to unlisted hosts blocked as expected"
 fi
 
 # Verify GitHub API access


### PR DESCRIPTION
## Summary
- Allow outbound HTTP (port 80) and HTTPS (port 443) to all destinations in the devcontainer firewall
- Enables `curl`, `wget`, web fetching, and API access without per-domain whitelisting
- Non-HTTP/HTTPS protocols remain restricted to the ipset-based domain allowlist

## Changes
- Added `iptables -A OUTPUT -p tcp --dport 80 -j ACCEPT` rule
- Added `iptables -A OUTPUT -p tcp --dport 443 -j ACCEPT` rule
- Updated comment to clarify ipset rules now cover non-HTTP protocols only
- Fixed verification test: changed from testing `curl https://example.com` (now expected to succeed) to testing `nc` on port 9999 to an unlisted host (expected to be blocked)

## Addressed Review Feedback
- **Issue 1 (verification test):** Fixed - updated test to verify non-HTTP traffic blocking instead of HTTP blocking
- **Issue 2 (security regression):** Acknowledged - this is an intentional design change per user request. The domain allowlist remains effective for non-HTTP protocols (SSH, custom TCP, etc.)

## Test Plan
- [ ] Rebuild devcontainer and verify `curl https://example.com` succeeds
- [ ] Verify `curl https://api.github.com/zen` still works
- [ ] Verify non-HTTP traffic to unlisted domains is still blocked (e.g., `nc -z example.com 9999` should fail)
- [ ] Verify init-firewall.sh runs without errors (verification tests pass)

Generated with Claude Code