### PR TITLE
fix: handle git submodule reference in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -33,7 +33,7 @@
     }
   },
   "forwardPorts": [3000, 4566, 5432, 9323],
-  "postCreateCommand": "bun install && git config --global worktree.guessRemote true && ([ -d .beads ] || bd init --quiet) && bash scripts/setup-git-hooks.sh && echo \"alias claude='claude --dangerously-skip-permissions'\" >> ~/.bashrc && echo \"alias claude='claude --dangerously-skip-permissions'\" >> ~/.zshrc",
+  "postCreateCommand": "bash scripts/devcontainer-setup.sh",
   "remoteUser": "bun",
   "postAttachCommand": ".devcontainer/install-plugins.sh",
   "mounts": [

--- a/scripts/devcontainer-setup.sh
+++ b/scripts/devcontainer-setup.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# Devcontainer postCreateCommand setup script.
+# Handles the case where tsumugi is a git submodule and the parent repo's
+# .git/modules/ directory isn't available inside the container.
+
+set -e
+
+# 1. Install dependencies
+bun install
+
+# 2. Fix git if running as a submodule in the container
+#    The .git file references ../../.git/modules/tsumugi which doesn't exist
+#    inside the container. We create a container-local git repo instead.
+if [ -f .git ] && ! git rev-parse --git-dir >/dev/null 2>&1; then
+  echo "Detected broken git submodule reference, initializing container-local git..."
+  GIT_LOCAL="/home/bun/.tsumugi-git"
+
+  git init --bare "$GIT_LOCAL"
+  git --git-dir="$GIT_LOCAL" remote add origin git@github.com:kokiebisu/tsumugi.git 2>/dev/null || true
+  git --git-dir="$GIT_LOCAL" config user.email "kokiebisu@icloud.com"
+  git --git-dir="$GIT_LOCAL" config user.name "neko"
+  git --git-dir="$GIT_LOCAL" config core.worktree /workspace
+
+  # Fetch from remote (SSH keys are mounted from host)
+  git --git-dir="$GIT_LOCAL" fetch origin 2>/dev/null || {
+    echo "Warning: Could not fetch from remote. Trying HTTPS..."
+    git --git-dir="$GIT_LOCAL" remote set-url origin https://github.com/kokiebisu/tsumugi.git
+    git --git-dir="$GIT_LOCAL" fetch origin 2>/dev/null || true
+  }
+
+  # Reset index to match remote main (working tree files are already present via bind mount)
+  git --git-dir="$GIT_LOCAL" --work-tree=/workspace reset --mixed origin/main 2>/dev/null || true
+
+  # Set GIT_DIR for the rest of this script
+  export GIT_DIR="$GIT_LOCAL"
+
+  # Persist for future shell sessions
+  for rc in ~/.bashrc ~/.zshrc; do
+    if ! grep -q 'GIT_DIR=.*tsumugi-git' "$rc" 2>/dev/null; then
+      cat >> "$rc" << 'GITENV'
+
+# Container-local git for submodule workaround
+export GIT_DIR=/home/bun/.tsumugi-git
+export GIT_WORK_TREE=/workspace
+GITENV
+    fi
+  done
+
+  echo "Git configured for container use (GIT_DIR=$GIT_LOCAL)"
+fi
+
+# 3. Global git config
+git config --global worktree.guessRemote true
+
+# 4. Initialize beads if needed
+[ -d .beads ] || bd init --quiet 2>/dev/null || true
+
+# 5. Setup git hooks (non-fatal if git is still not fully available)
+bash scripts/setup-git-hooks.sh 2>/dev/null || true
+
+# 6. Shell aliases for Claude Code
+grep -q 'alias claude=' ~/.bashrc 2>/dev/null || \
+  echo "alias claude='claude --dangerously-skip-permissions'" >> ~/.bashrc
+grep -q 'alias claude=' ~/.zshrc 2>/dev/null || \
+  echo "alias claude='claude --dangerously-skip-permissions'" >> ~/.zshrc


### PR DESCRIPTION
## Summary

- When tsumugi is used as a git submodule (inside the `life` repo), its `.git` file references `../../.git/modules/tsumugi` which doesn't exist inside the devcontainer
- The `postCreateCommand` was failing with `fatal: not a git repository` (exit code 128), preventing the container from starting
- Added `scripts/devcontainer-setup.sh` that detects the broken submodule reference and creates a container-local git repo by fetching from remote
- Standalone clones (non-submodule) are unaffected — the fix only activates when `.git` is a file and git commands fail

## Test plan

- [ ] Rebuild devcontainer when tsumugi is a submodule — should succeed without exit code 128
- [ ] Verify `git status`, `git log` work inside the container
- [ ] Verify standalone clone still works (`.git` is a directory, fix is skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)