### PR TITLE
feat: add deadline setting phase to meeting:tasks skill

### DIFF
--- a/.claude/commands/meeting:tasks.md
+++ b/.claude/commands/meeting:tasks.md
@@ -293,7 +293,7 @@ Deadlines are derived top-down from the roadmap (`docs/design/roadmap.md`), not 
 - [ ] タスクリスト（期限付き）を大株主が承認
 - [ ] `bd create` でBeadsタスク作成
 - [ ] Linear同期でLinearに登録
-- [ ] **Linearに期限と根拠を設定**（`scripts/linear-set-deadlines.py` を更新＆実行、または直接APIで設定）
+- [ ] **Linearに期限と根拠を設定**（Linear APIで直接設定、または `./scripts/linear-comment.sh` で根拠をコメント追加）
 - [ ] 開発セッションで実装開始
 
 ---


### PR DESCRIPTION
## Summary
- Add Phase 5 (deadline setting) to the `/meeting:tasks` skill flow
- Deadlines are derived top-down from the roadmap (`docs/design/roadmap.md`), not bottom-up from effort estimates
- CTO proposes deadlines via reverse-calculation from phase end dates; CPO adjusts for business events

## Changes
- Added Phase 5 with 3 steps: roadmap confirmation, deadline reverse-calculation, PO approval
- Updated output format tables to include deadline and rationale columns
- Added timeline section to meeting output
- Updated "When to Use" section with deadline setting use case
- Added note #6 "deadlines are top-down" to guidelines
- Updated workflow position diagram to include deadline setting
- Updated end-of-meeting checklist with Linear deadline setting step (using existing helper scripts)

## Review Feedback Addressed
- Removed reference to non-existent `linear-set-deadlines.py` script; use existing Linear helper scripts instead

## Test Plan
- [ ] Run `/meeting:tasks` and verify Phase 5 appears in the meeting flow
- [ ] Confirm output format includes deadline and rationale columns
- [ ] Verify checklist references existing Linear scripts only

Generated with Claude Code