### PR TITLE
fix: extend business keyword detection in linear-set-project

### DIFF
--- a/scripts/linear-set-project.sh
+++ b/scripts/linear-set-project.sh
@@ -102,7 +102,7 @@ except: print('')
 
   # Also check title keywords as fallback heuristic
   if [ "$IS_BUSINESS" = "false" ]; then
-    if echo "$TITLE" | grep -qEi "ヒアリング|タグライン|予算|法律|法務|規約|管理会社.*リスト|パートナー|マーケティング|Twitter|投稿|メールアドレスを作成|提案資料|振り返り|Stripe.*申請|書類.*準備|予約.*相談"; then
+    if echo "$TITLE" | grep -qEi "ヒアリング|タグライン|予算|法律|法務|規約|管理会社.*リスト|パートナー|マーケティング|Twitter|投稿|メールアドレスを作成|提案資料|振り返り|Stripe.*申請|書類.*準備|予約.*相談|参加する|イベント|Venture|Cafe|Gathering|カンファレンス|セミナー|ミートアップ|告知|成功事例|フォローアップ|清掃費|物件登録目標|紹介プログラム|コンテンツマーケ|CAC|LTV|内覧.*調整|フィードバック収集|不動産関係者|引き継ぎ契約|エスクロー|オーナー説明|仲介会社|紹介フィー|オペレーション自動化"; then
       IS_BUSINESS=true
     fi
   fi


### PR DESCRIPTION
## Summary
- Extend business keyword fallback heuristic in `linear-set-project.sh` to correctly route new task types to the Business project
- Remove unused `scripts/linear-set-deadlines.py` (one-shot script replaced by meeting:tasks Phase 5 flow)

## Changes
- Added keywords: events (イベント, Venture, Cafe, カンファレンス, セミナー, ミートアップ), outreach (告知, 不動産関係者, 仲介会社, 紹介フィー), operations (内覧調整, フィードバック収集, 引き継ぎ契約, エスクロー, 清掃費, 物件登録目標), growth (成功事例, フォローアップ, CAC, LTV, 紹介プログラム, コンテンツマーケ, オペレーション自動化, オーナー説明)

## Test Plan
- [ ] Run `./scripts/linear-set-project.sh` and verify new business tasks are routed to Business project
- [ ] Verify development tasks are still routed to Development project

Generated with Claude Code