### PR TITLE
test: consultation document PDF tests and generator

### DIFF
--- a/src/lib/pdf/__tests__/consultation-document.test.tsx
+++ b/src/lib/pdf/__tests__/consultation-document.test.tsx
@@ -117,4 +117,78 @@ describe('ConsultationDocument', () => {
     const json = JSON.stringify(element);
     expect(json).toContain('2026年2月7日');
   });
+
+  it('includes notes section, footer, and contact info', () => {
+    const element = ConsultationDocument(defaultProps);
+    const json = JSON.stringify(element);
+    expect(json).toContain('備考');
+    expect(json).toContain('内見');
+    expect(json).toContain('info@tsumugi.com');
+    expect(json).toContain('tsumugi. All rights reserved');
+    expect(json).toContain('https://tsumugi.com');
+  });
+
+  it('renders correctly with empty furniture list', () => {
+    const propsWithNoFurniture = { ...defaultProps, furnitureItems: [] };
+    const element = ConsultationDocument(propsWithNoFurniture);
+    expect(element).toBeTruthy();
+    const json = JSON.stringify(element);
+    expect(json).toContain('"children":["暫定家具リスト（",0,"点）"]');
+  });
+
+  it('renders correctly with single furniture item', () => {
+    const propsWithOne = {
+      ...defaultProps,
+      furnitureItems: [
+        { name: 'ベッド', category: 'コア', description: 'シングル' },
+      ],
+    };
+    const element = ConsultationDocument(propsWithOne);
+    const json = JSON.stringify(element);
+    expect(json).toContain('ベッド');
+    expect(json).toContain('"children":["暫定家具リスト（",1,"点）"]');
+  });
+
+  it('includes furniture categories and descriptions', () => {
+    const element = ConsultationDocument(defaultProps);
+    const json = JSON.stringify(element);
+    expect(json).toContain('コア');
+    expect(json).toContain('追加');
+    expect(json).toContain('3人掛け、良好');
+    expect(json).toContain('IKEA製');
+  });
+
+  it('includes all section headers and document title', () => {
+    const element = ConsultationDocument(defaultProps);
+    const json = JSON.stringify(element);
+    expect(json).toContain('残置物引き継ぎのご相談');
+    expect(json).toContain('物件情報');
+    expect(json).toContain('管理会社様へのお願い');
+  });
+
+  it('includes action step descriptions', () => {
+    const element = ConsultationDocument(defaultProps);
+    const json = JSON.stringify(element);
+    expect(json).toContain('本資料に記載の家具リスト');
+    expect(json).toContain('物件オーナー（大家）様');
+    expect(json).toContain('承認・条件付き承認・不承認');
+  });
+
+  it('includes table headers and property info labels', () => {
+    const element = ConsultationDocument(defaultProps);
+    const json = JSON.stringify(element);
+    expect(json).toContain('品名');
+    expect(json).toContain('カテゴリ');
+    expect(json).toContain('物件名');
+    expect(json).toContain('所在地');
+    expect(json).toContain('退去予定日');
+    expect(json).toContain('前の住人');
+  });
+
+  it('explains furniture list is provisional', () => {
+    const element = ConsultationDocument(defaultProps);
+    const json = JSON.stringify(element);
+    expect(json).toContain('暫定');
+    expect(json).toContain('最終的な引き継ぎ品目は合意時に確定');
+  });
 });

--- a/src/lib/pdf/__tests__/consultation-generator.test.ts
+++ b/src/lib/pdf/__tests__/consultation-generator.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildConsultationDocumentProps,
+  mapFurnitureToConsultationItems,
+} from '../consultation-generator';
+import type { FurnitureItem } from '../../data';
+
+describe('consultation document generator', () => {
+  const sampleFurnitureItems: FurnitureItem[] = [
+    {
+      type: 'bed',
+      photos: ['/bed.jpg'],
+      condition: 'excellent',
+      notes: 'シングルベッド',
+    },
+    {
+      type: 'sofa',
+      photos: ['/sofa.jpg'],
+      condition: 'good',
+      notes: '3人掛け',
+    },
+    { type: 'desk', photos: ['/desk.jpg'], condition: 'fair' },
+    { type: 'storage', photos: [] },
+  ];
+
+  const defaultInput = {
+    propertyName: '渋谷の家具付き1LDK',
+    propertyAddress: '東京都渋谷区神宮前1-2-3',
+    moveOutDate: '2026-03-31',
+    sellerName: '山田太郎',
+    furnitureItems: sampleFurnitureItems,
+  };
+
+  describe('mapFurnitureToConsultationItems', () => {
+    it('maps all furniture items with Japanese labels and categories', () => {
+      const items = mapFurnitureToConsultationItems(sampleFurnitureItems);
+      expect(items).toHaveLength(4);
+      expect(items[0].name).toBe('ベッド');
+      expect(items[1].name).toBe('ソファ');
+      expect(items[2].name).toBe('デスク');
+      expect(items[3].name).toBe('収納');
+    });
+
+    it('maps layer to correct category labels', () => {
+      const items = mapFurnitureToConsultationItems(sampleFurnitureItems);
+      // bed, sofa, desk are core; storage is additional
+      expect(items[0].category).toBe('コアセット（基本セット）');
+      expect(items[1].category).toBe('コアセット（基本セット）');
+      expect(items[2].category).toBe('コアセット（基本セット）');
+      expect(items[3].category).toBe('追加家具（個別オプション）');
+    });
+
+    it('includes notes as description, undefined when absent', () => {
+      const items = mapFurnitureToConsultationItems(sampleFurnitureItems);
+      expect(items[0].description).toBe('シングルベッド');
+      expect(items[1].description).toBe('3人掛け');
+      expect(items[2].description).toBeUndefined();
+      expect(items[3].description).toBeUndefined();
+    });
+
+    it('returns empty array for empty input', () => {
+      expect(mapFurnitureToConsultationItems([])).toEqual([]);
+    });
+
+    it('returns new array (immutability)', () => {
+      const items1 = mapFurnitureToConsultationItems(sampleFurnitureItems);
+      const items2 = mapFurnitureToConsultationItems(sampleFurnitureItems);
+      expect(items1).not.toBe(items2);
+      expect(items1).toEqual(items2);
+    });
+  });
+
+  describe('buildConsultationDocumentProps', () => {
+    it('builds complete props from property data', () => {
+      const props = buildConsultationDocumentProps(defaultInput);
+      expect(props.propertyName).toBe('渋谷の家具付き1LDK');
+      expect(props.propertyAddress).toBe('東京都渋谷区神宮前1-2-3');
+      expect(props.sellerName).toBe('山田太郎');
+      expect(props.furnitureItems).toHaveLength(4);
+      expect(props.furnitureItems[0].name).toBe('ベッド');
+      expect(props.furnitureItems[0].category).toBe('コアセット（基本セット）');
+    });
+
+    it('formats dates as Japanese date strings', () => {
+      const props = buildConsultationDocumentProps(defaultInput);
+      expect(props.moveOutDate).toMatch(/2026年3月31日/);
+      expect(props.createdDate).toMatch(/\d{4}年\d{1,2}月\d{1,2}日/);
+    });
+
+    it('handles empty furniture list', () => {
+      const props = buildConsultationDocumentProps({
+        ...defaultInput,
+        furnitureItems: [],
+      });
+      expect(props.furnitureItems).toEqual([]);
+    });
+
+    it('preserves all input fields in output', () => {
+      const props = buildConsultationDocumentProps({
+        ...defaultInput,
+        propertyName: '物件A',
+        propertyAddress: '住所B',
+        sellerName: '名前C',
+      });
+      expect(props.propertyName).toBe('物件A');
+      expect(props.propertyAddress).toBe('住所B');
+      expect(props.sellerName).toBe('名前C');
+    });
+  });
+});

--- a/src/lib/pdf/consultation-generator.ts
+++ b/src/lib/pdf/consultation-generator.ts
@@ -1,0 +1,87 @@
+/**
+ * 残置物引き継ぎ相談資料PDF生成（Phase 2）
+ *
+ * 物件データから ConsultationDocument テンプレートに必要な
+ * props を構築する。管理会社向けの相談資料PDFに使用。
+ */
+
+import type { FurnitureItem } from '../data';
+import { furnitureLabels } from '../data';
+import { isCoreFurniture, getLayerLabel } from '../furniture-layers';
+
+interface ConsultationFurnitureItem {
+  name: string;
+  category: string;
+  description?: string;
+}
+
+interface ConsultationDocumentProps {
+  propertyName: string;
+  propertyAddress: string;
+  moveOutDate: string;
+  sellerName: string;
+  furnitureItems: ConsultationFurnitureItem[];
+  createdDate: string;
+}
+
+interface BuildConsultationDocumentInput {
+  propertyName: string;
+  propertyAddress: string;
+  moveOutDate: string;
+  sellerName: string;
+  furnitureItems: FurnitureItem[];
+}
+
+/**
+ * Maps property furniture items to consultation document format.
+ * Each item gets a Japanese label and layer-based category.
+ */
+export function mapFurnitureToConsultationItems(
+  items: FurnitureItem[]
+): ConsultationFurnitureItem[] {
+  return items.map((item) => {
+    const layer = isCoreFurniture(item.type) ? 'core' : 'additional';
+
+    return {
+      name: furnitureLabels[item.type] ?? item.type,
+      category: getLayerLabel(layer),
+      description: item.notes,
+    };
+  });
+}
+
+/**
+ * Formats an ISO date string (YYYY-MM-DD) as a Japanese date (YYYY年M月D日).
+ */
+function formatJapaneseDate(isoDate: string): string {
+  const date = new Date(isoDate);
+  return date.toLocaleDateString('ja-JP', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+}
+
+/**
+ * Builds complete props for the ConsultationDocument PDF component
+ * from property data.
+ */
+export function buildConsultationDocumentProps(
+  input: BuildConsultationDocumentInput
+): ConsultationDocumentProps {
+  const now = new Date();
+  const createdDate = now.toLocaleDateString('ja-JP', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+
+  return {
+    propertyName: input.propertyName,
+    propertyAddress: input.propertyAddress,
+    moveOutDate: formatJapaneseDate(input.moveOutDate),
+    sellerName: input.sellerName,
+    furnitureItems: mapFurnitureToConsultationItems(input.furnitureItems),
+    createdDate,
+  };
+}

--- a/src/lib/pdf/index.ts
+++ b/src/lib/pdf/index.ts
@@ -10,3 +10,7 @@ export {
   mapChecklistToConsentItems,
 } from './consent-generator';
 export { buildAgreementPdfProps, generateAgreementPdf } from './agreement-pdf';
+export {
+  buildConsultationDocumentProps,
+  mapFurnitureToConsultationItems,
+} from './consultation-generator';


### PR DESCRIPTION
## Summary
- Enhanced `ConsultationDocument` template tests from 13 to 21 test cases covering all sections, edge cases (empty/single furniture lists), footer, notes, labels, and provisional list disclaimer
- Created `consultation-generator.ts` with `mapFurnitureToConsultationItems` and `buildConsultationDocumentProps` functions to build template props from property `FurnitureItem` data
- Added 9 comprehensive tests for the generator covering Japanese label mapping, layer-based categorization, date formatting, immutability, and edge cases
- Exported new generator functions from `src/lib/pdf/index.ts`

## Test plan
- [x] All 30 consultation PDF tests pass (`bun run test:run -- src/lib/pdf/__tests__/consultation-document.test.tsx src/lib/pdf/__tests__/consultation-generator.test.ts`)
- [x] All 112 PDF module tests pass (`bun run test:run -- src/lib/pdf/__tests__/`)
- [x] No lint errors in changed files
- [x] No TypeScript errors in changed files

Closes tsumugi-8qk

🤖 Generated with [Claude Code](https://claude.com/claude-code)