### PR TITLE
fix: filter Linear issues by state type instead of name

### DIFF
--- a/scripts/linear-list.sh
+++ b/scripts/linear-list.sh
@@ -31,7 +31,7 @@ echo ""
 curl -s -X POST \
   -H "Content-Type: application/json" \
   -H "Authorization: $LINEAR_API_KEY" \
-  -d "{\"query\":\"query { issues(filter: { team: { id: { eq: \\\"$LINEAR_TEAM_ID\\\" } }, state: { name: { nin: [\\\"Done\\\", \\\"Canceled\\\"] } } }, orderBy: updatedAt) { nodes { id identifier title state { name } assignee { name } createdAt updatedAt } } }\"}" \
+  -d "{\"query\":\"query { issues(filter: { team: { id: { eq: \\\"$LINEAR_TEAM_ID\\\" } }, state: { type: { nin: [\\\"completed\\\", \\\"canceled\\\"] } } }, orderBy: updatedAt) { nodes { id identifier title state { name } assignee { name } createdAt updatedAt } } }\"}" \
   https://api.linear.app/graphql | python3 -c "
 import sys, json
 from datetime import datetime


### PR DESCRIPTION
## Summary
- **linear-list.sh** was filtering open issues by state `name` (excluding "Done" and "Canceled"), which missed custom canceled-type states like "Duplicate"
- Changed filter to use state `type` (`completed`, `canceled`) so all closed/canceled states are properly excluded regardless of custom naming

## Changes
- `scripts/linear-list.sh`: Changed GraphQL filter from `state.name nin ["Done", "Canceled"]` to `state.type nin ["completed", "canceled"]`

## Test Plan
- [x] Run `./scripts/linear-list.sh` and verify no Duplicate/Canceled issues appear
- [x] Verify Todo/Backlog/In Progress issues still appear correctly

Generated with Claude Code