### PR TITLE
feat: add /team:research command and Agent Teams pipeline docs

### DIFF
--- a/.claude/commands/team:research.md
+++ b/.claude/commands/team:research.md
@@ -1,0 +1,258 @@
+---
+description: Agent Teams pre-meeting research sprint. Spawns researchers for parallel investigation. CLI only.
+allowed-tools: Bash, Read, Write, Grep, Glob, WebFetch, WebSearch
+---
+
+# /team:research - Pre-Meeting Research Sprint
+
+Spawn an agent team to research topics before a C-suite meeting. Populates executive knowledge bases with fresh data so meetings start informed.
+
+**Arguments:** `$ARGUMENTS` (meeting type + topic, e.g. `exec Q2戦略`, `product 内見予約フロー`, `tech リアルタイム通知`)
+
+## Prerequisites
+
+- `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` must be set
+- Interactive CLI session
+
+## When to Use
+
+- Before `/meeting:exec` -- research market trends, competitor moves, industry data
+- Before `/meeting:product` -- research user feedback, competitor UX, market needs
+- Before `/meeting:tech` -- research technology options, architecture patterns, benchmarks
+- Before `/meeting:gtm` -- research channels, marketing tactics, competitor positioning
+- Before `/meeting:architecture` -- research design patterns, scalability approaches
+- Before `/meeting:tools` -- research tool options, comparisons, pricing
+
+## Phase 1: Research Brief
+
+Parse `$ARGUMENTS` to determine:
+
+1. **Target meeting type** (exec / product / tech / gtm / architecture / tools)
+2. **Research topic(s)**
+
+Based on meeting type, determine research team composition:
+
+| Meeting Type | Researchers                     | Knowledge Bases to Populate |
+| ------------ | ------------------------------- | --------------------------- |
+| exec         | market, user, tech, competitive | CEO, CPO, CTO, CMO          |
+| product      | user, competitive, market       | CPO, CMO                    |
+| tech         | tech, architecture, tools       | CTO, CAIO                   |
+| gtm          | competitive, channels, market   | CMO, CEO                    |
+| architecture | tech, architecture, patterns    | CTO, CAIO                   |
+| tools        | tools, benchmarks, pricing      | CTO, CAIO                   |
+
+## Phase 2: Spawn Research Team
+
+Create an agent team with researchers matched to the meeting type. Use **delegate mode**.
+
+### For `exec` meetings (4 researchers):
+
+```
+Create an agent team for pre-meeting research.
+Topic: {topic}. This feeds into a /meeting:exec.
+Spawn 4 researcher teammates. Use delegate mode.
+
+1. Teammate "market-researcher":
+   Research market trends, industry benchmarks, funding landscape
+   related to {topic}.
+   Use WebSearch for current data (2025-2026).
+   Focus on: Japanese real estate tech, proptech trends, C2C platforms.
+   Save findings to: docs/team/ceo/knowledge/YYYY-MM-DD-research-{slug}.md
+
+2. Teammate "user-researcher":
+   Research user behavior, UX patterns, customer feedback
+   related to {topic}.
+   Read existing personas: docs/team/personas/
+   Read existing requirements: docs/requirements/
+   Save findings to: docs/team/cpo/knowledge/YYYY-MM-DD-research-{slug}.md
+
+3. Teammate "tech-researcher":
+   Research technical approaches, libraries, architecture patterns
+   for {topic}.
+   Compare options with pros/cons, consider our stack (Next.js/Bun/TypeScript).
+   Save findings to: docs/team/cto/knowledge/YYYY-MM-DD-research-{slug}.md
+
+4. Teammate "competitive-researcher":
+   Research competitor products, their approaches to {topic}.
+   Focus on: Japanese market (ジモティー, メルカリ), global (Airbnb, Zillow).
+   Analyze strengths, weaknesses, opportunities for tsumugi.
+   Save findings to: docs/team/cmo/knowledge/YYYY-MM-DD-research-{slug}.md
+
+Share relevant findings with each other during research.
+A market trend might affect technical feasibility, and vice versa.
+```
+
+### For `product` meetings (3 researchers):
+
+```
+Spawn 3 researcher teammates:
+
+1. Teammate "user-researcher":
+   Deep dive into user needs, pain points, and behavior patterns for {topic}.
+   Read personas: docs/team/personas/
+   Read past meeting notes: docs/requirements/meetings/
+   Save to: docs/team/cpo/knowledge/YYYY-MM-DD-research-{slug}.md
+
+2. Teammate "competitive-researcher":
+   How do competitors handle {topic}? UX patterns, feature comparison.
+   Save to: docs/team/cmo/knowledge/YYYY-MM-DD-research-{slug}.md
+
+3. Teammate "market-researcher":
+   Market size, demand signals, pricing benchmarks for {topic}.
+   Save to: docs/team/ceo/knowledge/YYYY-MM-DD-research-{slug}.md
+```
+
+### For `tech` meetings (3 researchers):
+
+```
+Spawn 3 researcher teammates:
+
+1. Teammate "tech-researcher":
+   Research implementation approaches for {topic}.
+   Compare libraries, frameworks, services. Benchmark performance.
+   Consider our stack: Next.js 16, Bun, TypeScript, Tailwind, shadcn/ui.
+   Save to: docs/team/cto/knowledge/YYYY-MM-DD-research-{slug}.md
+
+2. Teammate "architecture-researcher":
+   Research architecture patterns for {topic}.
+   Scalability, maintainability, testing considerations.
+   Read current design: docs/DESIGN_DOC.md
+   Save to: docs/team/cto/knowledge/YYYY-MM-DD-research-{slug}-arch.md
+
+3. Teammate "ai-researcher":
+   Research AI/ML capabilities for {topic}.
+   LLM APIs, embedding models, vector databases, automation patterns.
+   Realistic assessment of what AI can/cannot do here.
+   Save to: docs/team/caio/knowledge/YYYY-MM-DD-research-{slug}.md
+```
+
+### For `gtm` meetings (3 researchers):
+
+```
+Spawn 3 researcher teammates:
+
+1. Teammate "competitive-researcher":
+   Competitor positioning, messaging, channel strategy for {topic}.
+   Save to: docs/team/cmo/knowledge/YYYY-MM-DD-research-{slug}.md
+
+2. Teammate "channels-researcher":
+   Marketing channels, CAC benchmarks, growth tactics for {topic}.
+   Focus on: Japanese market, SNS (Twitter/X, Instagram, LINE), SEO, referral.
+   Save to: docs/team/cmo/knowledge/YYYY-MM-DD-research-{slug}-channels.md
+
+3. Teammate "market-researcher":
+   Market sizing, target segments, demand validation for {topic}.
+   Save to: docs/team/ceo/knowledge/YYYY-MM-DD-research-{slug}.md
+```
+
+## Researcher Output Format
+
+Each researcher saves to their executive's knowledge folder:
+
+```markdown
+# Research: {topic}
+
+**Date:** YYYY-MM-DD
+**Researcher:** {role}
+**For meeting:** /meeting:{type}
+
+## Key Findings
+
+1. **[Finding title]**
+   [Details with data/evidence]
+   Source: [URL or reference]
+
+2. **[Finding title]**
+   [Details with data/evidence]
+   Source: [URL or reference]
+
+## Implications for tsumugi
+
+- [How this affects our strategy/product/tech]
+- [Opportunities identified]
+- [Risks to consider]
+
+## Recommendations
+
+- [Actionable recommendation for the meeting]
+
+## Sources
+
+- [URL 1]
+- [URL 2]
+```
+
+## Phase 3: Research Brief Synthesis
+
+After all researchers complete, the lead creates a unified brief:
+
+```markdown
+# Research Brief: {topic}
+
+**Date:** YYYY-MM-DD
+**For:** /meeting:{type}
+**Researchers:** {list}
+
+## Executive Summary
+
+[2-3 sentence overview of key findings]
+
+## Findings by Domain
+
+### Market & Industry
+
+[Key findings from market-researcher]
+
+### User & Product
+
+[Key findings from user-researcher]
+
+### Technical
+
+[Key findings from tech-researcher]
+
+### Competitive Landscape
+
+[Key findings from competitive-researcher]
+
+## Cross-Cutting Insights
+
+[Where findings from different domains connect or conflict]
+
+## Suggested Meeting Agenda Points
+
+1. [Informed by research -- most impactful topic first]
+2. [...]
+3. [...]
+
+## Open Questions
+
+[Questions that research couldn't fully answer -- bring to meeting]
+```
+
+Save brief to: `docs/research/YYYY-MM-DD-{topic-slug}.md`
+
+## Phase 4: Cleanup
+
+Dismiss the team after research is complete.
+
+Print: "Research sprint complete. Knowledge bases updated. Run `/meeting:{type}` to start the meeting."
+
+## Example Usage
+
+```
+/team:research exec 2026年Q1レビューとQ2戦略
+/team:research product 内見予約フロー
+/team:research tech リアルタイムマッチング通知
+/team:research gtm ローンチキャンペーン
+```
+
+## Full Pipeline
+
+```
+/team:research {type} {topic}     -- Parallel research (Agent Teams)
+  -> /meeting:{type}              -- C-suite decides (single session)
+  -> /meeting:tasks               -- Decompose to tasks
+  -> /team:dev                    -- Parallel implementation (Agent Teams)
+  -> /team:review                 -- Parallel review (Agent Teams)
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,22 @@ Secret: `ANTHROPIC_AUTH_TOKEN`, env: `CLAUDE_CODE_OAUTH_TOKEN`
 4. `docs/requirements/features/` 内の関連ファイルに座談会参照リンクを追加
 5. **PRを作成してマージ**（docs変更のみのためauto-merge対象）
 
+## Agent Teams Pipeline (CLI Only)
+
+`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` (set in `.claude/settings.json`)
+
+```
+/team:research (parallel research)  ->  /meeting:* (C-suite decides)  ->  /team:dev (parallel build)  ->  /team:review (parallel review)
+```
+
+| Command          | Purpose                                    | CI Fallback             |
+| ---------------- | ------------------------------------------ | ----------------------- |
+| `/team:research` | Pre-meeting parallel research sprint       | Manual research         |
+| `/team:dev`      | Parallel task implementation (Agent Teams) | `/work:dev` (subagents) |
+| `/team:review`   | Parallel code review (Agent Teams)         | Code review agent       |
+
+Agent Teams is CLI-only. For GitHub Actions, use `/work:dev` and `/work:business`.
+
 ## Related Docs
 
 - `.claude/PROJECT.md` — コンセプト・デザイン原則

--- a/docs/team/ORGANIZATION.md
+++ b/docs/team/ORGANIZATION.md
@@ -28,6 +28,18 @@ graph TD
 
     TECH --> TASKS["タスク分解会議<br/>/meeting:tasks"]
     TASKS --> DEV["開発"]
+
+    subgraph TEAMS["Agent Teams（CLI専用）"]
+        RES["事前リサーチ<br/>/team:research"]
+        TDEV["並列開発<br/>/team:dev"]
+        TREV["並列レビュー<br/>/team:review"]
+    end
+
+    RES -.->|"knowledgeフォルダ更新"| EXEC
+    RES -.->|"knowledgeフォルダ更新"| PROD
+    TASKS -->|"Agent Teams"| TDEV
+    TDEV -->|"PR作成"| TREV
+    TREV -->|"承認/修正要求"| MERGE["マージ"]
 ```
 
 ---
@@ -111,6 +123,112 @@ graph LR
 - TDD（テスト駆動開発）で実装
 - PRは~300行以内、CI全チェック必須
 - コードレビュー → マージ
+
+---
+
+## Agent Teams による並列実行（CLI専用）
+
+`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` を有効にすると、複数の独立したClaude Codeインスタンスが並列に作業できる。従来のサブエージェント（Task tool）とは異なり、チームメイト同士が直接コミュニケーション可能。
+
+### フルパイプライン
+
+```mermaid
+graph LR
+    R["Step 0<br/>/team:research<br/><i>並列リサーチ</i>"]
+    P["Step 1<br/>/meeting:product<br/><i>何を作るか</i>"]
+    T["Step 2<br/>/meeting:tech<br/><i>どう作るか</i>"]
+    K["Step 3<br/>/meeting:tasks<br/><i>いつ・誰が</i>"]
+    D["Step 4<br/>/team:dev<br/><i>並列開発</i>"]
+    V["Step 5<br/>/team:review<br/><i>並列レビュー</i>"]
+
+    R -->|"knowledge更新"| P
+    P -->|"デルタサマリー"| T
+    T -->|"確定要件"| K
+    K -->|"Beads → Linear"| D
+    D -->|"PR作成"| V
+    V -->|"承認 → マージ"| M["完了"]
+```
+
+### /team:research — 事前リサーチスプリント
+
+会議の前に、リサーチャーチームを並列で派遣し、各役員のknowledgeフォルダを最新データで更新する。
+
+```
+/team:research exec Q2戦略
+/team:research product 内見予約フロー
+/team:research tech リアルタイム通知
+```
+
+| ミーティング | リサーチャー               | 更新先             |
+| ------------ | -------------------------- | ------------------ |
+| exec         | 市場, ユーザー, 技術, 競合 | CEO, CPO, CTO, CMO |
+| product      | ユーザー, 競合, 市場       | CPO, CMO           |
+| tech         | 技術, アーキテクチャ, AI   | CTO, CAIO          |
+| gtm          | 競合, チャネル, 市場       | CMO, CEO           |
+
+**効果:** C-suiteミーティングが「調べてから議論」ではなく、「調べた上で議論」になる。
+
+### /team:dev — 並列開発
+
+最大5つのタスクを独立したチームメイトが同時に実装する。各チームメイトは自分専用のgit worktreeで作業し、ファイル競合を回避。
+
+```
+/team:dev           # 全フェーズ
+/team:dev phase-1   # Phase 1のみ
+```
+
+**従来の `/work:dev` との違い:**
+
+|                    | `/work:dev`（サブエージェント） | `/team:dev`（Agent Teams）     |
+| ------------------ | ------------------------------- | ------------------------------ |
+| 並列性             | Task tool（報告のみ）           | 独立インスタンス（相互通信可） |
+| コミュニケーション | メインに報告するだけ            | チームメイト間で直接やり取り   |
+| 環境               | CLI + CI/GitHub Actions         | CLI専用                        |
+| コスト             | 低い                            | 高い（N倍のトークン）          |
+| 向いている場面     | 自動化、ルーティン              | 複雑な機能、相互依存タスク     |
+
+**ルール:**
+
+- リードはdelegate mode（調整のみ、自分では実装しない）
+- 各チームメイトは専用worktreeで作業
+- APIやインターフェース変更時は他チームメイトに通知
+- plan approval必須（実装前にリードが承認）
+
+### /team:review — 並列コードレビュー
+
+4人の専門レビュワーがPRを同時にレビューする。
+
+```
+/team:review #142
+/team:review feat/auth-flow
+```
+
+| レビュワー        | 観点                                                           |
+| ----------------- | -------------------------------------------------------------- |
+| security-reviewer | セキュリティ（OWASP Top 10、秘密値、認証）                     |
+| quality-reviewer  | コード品質（関数サイズ、不変性、命名）                         |
+| test-reviewer     | テスト（カバレッジ、TDD、エッジケース）                        |
+| perf-reviewer     | パフォーマンス（アルゴリズム、再レンダリング、バンドルサイズ） |
+
+**判定:** APPROVE / REQUEST CHANGES / BLOCK
+
+レビュー後、リードが全結果を統合レポートにまとめ、PRにコメントする。
+
+### CI/GitHub Actions との使い分け
+
+```mermaid
+graph TD
+    Q{環境は?}
+    Q -->|"CLI（対話型）"| TEAMS["Agent Teams<br/>/team:dev, /team:review"]
+    Q -->|"CI / GitHub Actions"| SUB["サブエージェント<br/>/work:dev, /work:business"]
+
+    TEAMS --> MERGE["PR → マージ"]
+    SUB --> MERGE
+```
+
+- **CLI（対話型セッション）:** `/team:*` コマンドを使用。深いコーディネーション、相互通信、plan approval付き。
+- **CI / GitHub Actions:** `/work:dev`, `/work:business` を使用。サブエージェントベースで自動実行。
+- 両方とも同じBeads/Linearタスク管理を使用。結果は同じ（PR → CI → マージ）。
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds `/team:research` slash command for pre-meeting parallel research sprints
- Updates `CLAUDE.md` with Agent Teams Pipeline reference section
- Updates `docs/team/ORGANIZATION.md` with full pipeline documentation including mermaid diagrams

## Changes
- New file: `.claude/commands/team:research.md`
  - Research team compositions per meeting type (exec/product/tech/gtm)
  - Researcher output format and knowledge base integration
  - Research brief synthesis template
- Updated: `CLAUDE.md` — Agent Teams Pipeline quick reference table
- Updated: `docs/team/ORGANIZATION.md`
  - Org chart expanded with Agent Teams subgraph
  - Full 6-step pipeline diagram (research -> product -> tech -> tasks -> dev -> review)
  - Detailed docs for /team:research, /team:dev, /team:review
  - Comparison table: Agent Teams vs subagents
  - CI vs CLI decision flow diagram

## Test Plan
- [ ] `/team:research` appears in slash command list
- [ ] Mermaid diagrams render correctly on GitHub
- [ ] Existing meeting commands unaffected
- [ ] No code changes — markdown only, no build impact

Generated with Claude Code