### PR TITLE
chore: add build verification rules to workflow and standards

### DIFF
--- a/.claude/rules/standards.md
+++ b/.claude/rules/standards.md
@@ -30,6 +30,12 @@ const key = process.env.API_KEY;
 if (!key) throw new Error('API_KEY not configured');
 ```
 
+## Build Integrity (CRITICAL)
+
+- **NEVER mark a task as "done"** unless `bun run build` passes
+- **Type consistency:** When using union types (e.g., status: `'draft' | 'public'`), grep the codebase for all usages before changing or adding values
+- **CI must include build:** If `bun run build` is missing from CI, add it before merging any feature PR
+
 ## Agent Auto-Invocation
 
 Claude auto-invokes agents — no user prompt needed:

--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -29,6 +29,14 @@ gh pr create --title "<type>: <desc>" --body "..."
 
 Chaining these risks permanently breaking the shell if any step fails.
 
+## Build Verification (CRITICAL)
+
+**ALWAYS run `bun run build` locally before creating a PR.** CI alone is not sufficient — if CI lacks a build step, type errors slip through silently.
+
+- `bun run build` catches TypeScript errors that ESLint and tests miss
+- If build fails, fix ALL type errors before pushing
+- NEVER merge a PR without confirming the build passes (locally or in CI)
+
 ## PR Process (CRITICAL)
 
 **NEVER STOP until merge is complete.** Full sequence:
@@ -39,7 +47,7 @@ Chaining these risks permanently breaking the shell if any step fails.
 4. Check PR comments: `gh pr view <n> --comments` + `gh pr reviews <n>`
 5. Address all relevant review feedback
 6. Merge: `gh pr merge <n> --squash --delete-branch`
-7. Return to main: `git checkout main && git pull origin main`
+7. **Remove worktree (3 SEPARATE Bash calls):** `cd /workspace` | `git worktree remove /workspace/.worktrees/<name> --force` | `git branch -D <branch> 2>/dev/null; git pull origin main`
 8. Update PR description after each push: `gh pr edit <n> --body "..."`
 
 **Auto-merge** all changes except: breaking API changes, major architecture decisions, 10+ file features.


### PR DESCRIPTION
## Summary
- Add Build Integrity section to standards.md (never mark tasks done without passing build, type consistency checks, CI must include build)
- Add Build Verification section to workflow.md (always run `bun run build` locally before PRs)
- Update PR process step 7 to use safe 3-step worktree cleanup pattern

## Changes
- `.claude/rules/standards.md`: Added Build Integrity (CRITICAL) section
- `.claude/rules/workflow.md`: Added Build Verification (CRITICAL) section, updated worktree cleanup in PR process

## Test Plan
- [x] Build passes (`bun run build`)
- [x] No functional code changes (documentation/rules only)

Generated with Claude Code