### PR TITLE
ci: Add label color management to auto-label workflow

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -15,6 +15,53 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Ensure label colors
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const labelColors = {
+              // Type labels (conventional commits)
+              'feature':       '1a7f37',
+              'bugfix':        'd73a4a',
+              'documentation': '0075ca',
+              'refactor':      '6f42c1',
+              'testing':       'e3b341',
+              'chore':         '666666',
+              'performance':   'd93f0b',
+              'ci':            '0052cc',
+              // Path-based labels
+              'e2e:run':       '0e6655',
+              'auth':          'e11d48',
+              'payments':      'b8860b',
+              'ui':            'd876e3',
+              'api':           '006b75',
+              // Size labels
+              'size:S':        'c2e0c6',
+              'size:M':        'fef2c0',
+              'size:L':        'f9d0c4',
+              'size:XL':       'e99695',
+            };
+
+            for (const [name, color] of Object.entries(labelColors)) {
+              try {
+                await github.rest.issues.updateLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name,
+                  color,
+                });
+              } catch (e) {
+                if (e.status === 404) {
+                  await github.rest.issues.createLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    name,
+                    color,
+                  });
+                }
+              }
+            }
+
       - name: Auto-label PR
         uses: actions/github-script@v7
         with:


### PR DESCRIPTION
## Summary

- Add automated label color management to the auto-label GitHub Actions workflow
- Ensures consistent label colors across type, path-based, and size categories
- Creates missing labels and updates existing ones to maintain color consistency

## Type

- [x] ci: CI/CD changes

## Test plan

- [x] Manual testing: Workflow will execute on next PR and verify labels are created/updated with correct colors

## Checklist

- [x] No hardcoded secrets or console.log
- [x] Changes are <300 lines (or justified)

https://claude.ai/code/session_01HnGuQu1rqdQwpfQLqqaCwd