### PR TITLE
fix: allow dependabot bot in claude code review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -39,5 +39,6 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          allowed_bots: 'dependabot[bot]'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options


### PR DESCRIPTION
## Summary

- Add `allowed_bots: 'dependabot[bot]'` to the claude-code-review workflow so automated reviews can run on dependabot PRs

## Context

All dependabot PRs (#361-363, #365-369) fail the `claude-review` check with:
> Workflow initiated by non-human actor: dependabot (type: Bot). Add bot to allowed_bots list or use '*' to allow all bots.

## Test plan

- [ ] After merge, re-trigger claude-review on a dependabot PR to verify it passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)