### PR TITLE
ci: add workflow to sync GitHub secrets to Vercel

### DIFF
--- a/.github/workflows/sync-vercel-env.yml
+++ b/.github/workflows/sync-vercel-env.yml
@@ -1,0 +1,53 @@
+name: Sync Secrets to Vercel
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: "Type 'sync' to confirm"
+        required: true
+
+# Only one sync at a time
+concurrency:
+  group: vercel-env-sync
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    name: Sync environment variables
+    runs-on: ubuntu-latest
+    if: github.event.inputs.confirm == 'sync'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Vercel CLI
+        run: npm i -g vercel@latest
+
+      - name: Sync secrets to Vercel
+        run: bash scripts/sync-env-to-vercel.sh
+        env:
+          # Vercel auth
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+          # App secrets — add matching GitHub secret for each
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          BETTER_AUTH_SECRET: ${{ secrets.BETTER_AUTH_SECRET }}
+          GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
+          GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
+          APPLE_CLIENT_ID: ${{ secrets.APPLE_CLIENT_ID }}
+          APPLE_CLIENT_SECRET: ${{ secrets.APPLE_CLIENT_SECRET }}
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_BUCKET_NAME: ${{ secrets.R2_BUCKET_NAME }}
+          R2_PUBLIC_URL: ${{ secrets.R2_PUBLIC_URL }}
+          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+          EMAIL_FROM: ${{ secrets.EMAIL_FROM }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+          STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
+          NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY }}
+          NEXT_PUBLIC_USE_AI_ESTIMATE: ${{ secrets.NEXT_PUBLIC_USE_AI_ESTIMATE }}

--- a/scripts/sync-env-to-vercel.sh
+++ b/scripts/sync-env-to-vercel.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Sync environment variables from GitHub Actions secrets to Vercel.
+# Usage: Called by .github/workflows/sync-vercel-env.yml
+# Requires: VERCEL_TOKEN, VERCEL_ORG_ID, VERCEL_PROJECT_ID
+set -euo pipefail
+
+# Map of Vercel env var name → value (passed as env vars from GitHub secrets)
+# Add/remove entries here when secrets change.
+declare -A ENV_VARS=(
+  # Database
+  ["DATABASE_URL"]="${DATABASE_URL:-}"
+
+  # Auth
+  ["BETTER_AUTH_SECRET"]="${BETTER_AUTH_SECRET:-}"
+  ["GOOGLE_CLIENT_ID"]="${GOOGLE_CLIENT_ID:-}"
+  ["GOOGLE_CLIENT_SECRET"]="${GOOGLE_CLIENT_SECRET:-}"
+  ["APPLE_CLIENT_ID"]="${APPLE_CLIENT_ID:-}"
+  ["APPLE_CLIENT_SECRET"]="${APPLE_CLIENT_SECRET:-}"
+
+  # Storage (Cloudflare R2)
+  ["R2_ACCOUNT_ID"]="${R2_ACCOUNT_ID:-}"
+  ["R2_ACCESS_KEY_ID"]="${R2_ACCESS_KEY_ID:-}"
+  ["R2_SECRET_ACCESS_KEY"]="${R2_SECRET_ACCESS_KEY:-}"
+  ["R2_BUCKET_NAME"]="${R2_BUCKET_NAME:-}"
+  ["R2_PUBLIC_URL"]="${R2_PUBLIC_URL:-}"
+
+  # Email
+  ["RESEND_API_KEY"]="${RESEND_API_KEY:-}"
+  ["EMAIL_FROM"]="${EMAIL_FROM:-}"
+
+  # AI
+  ["ANTHROPIC_API_KEY"]="${ANTHROPIC_API_KEY:-}"
+
+  # Stripe
+  ["STRIPE_SECRET_KEY"]="${STRIPE_SECRET_KEY:-}"
+  ["STRIPE_WEBHOOK_SECRET"]="${STRIPE_WEBHOOK_SECRET:-}"
+
+  # Public vars (non-secret but environment-specific)
+  ["NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY"]="${NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY:-}"
+  ["NEXT_PUBLIC_USE_AI_ESTIMATE"]="${NEXT_PUBLIC_USE_AI_ESTIMATE:-}"
+)
+
+# Target environments: production, preview, development
+TARGETS=("production" "preview")
+
+synced=0
+skipped=0
+failed=0
+
+for name in "${!ENV_VARS[@]}"; do
+  value="${ENV_VARS[$name]}"
+
+  if [[ -z "$value" ]]; then
+    echo "SKIP: $name (empty)"
+    ((skipped++))
+    continue
+  fi
+
+  for target in "${TARGETS[@]}"; do
+    # Remove existing value first (ignore errors if it doesn't exist)
+    vercel env rm "$name" "$target" --yes --token="$VERCEL_TOKEN" 2>/dev/null || true
+
+    # Add new value
+    if echo "$value" | vercel env add "$name" "$target" --token="$VERCEL_TOKEN" --force; then
+      echo "OK:   $name → $target"
+      ((synced++))
+    else
+      echo "FAIL: $name → $target"
+      ((failed++))
+    fi
+  done
+done
+
+echo ""
+echo "Done: $synced synced, $skipped skipped, $failed failed"
+
+if [[ $failed -gt 0 ]]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Adds `scripts/sync-env-to-vercel.sh` — maps GitHub secrets to Vercel env vars
- Adds `.github/workflows/sync-vercel-env.yml` — manual workflow (type "sync" to confirm)
- GitHub secrets become the single source of truth for all environment variables

## How to use
1. Add app secrets to GitHub repo secrets (DATABASE_URL, etc.)
2. Go to Actions → "Sync Secrets to Vercel" → Run workflow → type `sync`
3. Secrets are pushed to Vercel production + preview environments

## Test plan
- [ ] Verify workflow appears in Actions tab
- [ ] Add a test secret and run the workflow
- [ ] Confirm env var appears in Vercel dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)