### PR TITLE
fix: bash arithmetic exit code bug in vercel env sync

### DIFF
--- a/scripts/sync-env-to-vercel.sh
+++ b/scripts/sync-env-to-vercel.sh
@@ -52,21 +52,17 @@ for name in "${!ENV_VARS[@]}"; do
 
   if [[ -z "$value" ]]; then
     echo "SKIP: $name (empty)"
-    ((skipped++))
+    skipped=$((skipped + 1))
     continue
   fi
 
   for target in "${TARGETS[@]}"; do
-    # Remove existing value first (ignore errors if it doesn't exist)
-    vercel env rm "$name" "$target" --yes --token="$VERCEL_TOKEN" 2>/dev/null || true
-
-    # Add new value
     if echo "$value" | vercel env add "$name" "$target" --token="$VERCEL_TOKEN" --force; then
       echo "OK:   $name → $target"
-      ((synced++))
+      synced=$((synced + 1))
     else
       echo "FAIL: $name → $target"
-      ((failed++))
+      failed=$((failed + 1))
     fi
   done
 done


### PR DESCRIPTION
## Summary
- `((synced++))` returns exit code 1 when synced is 0 (bash treats 0 as falsy), killing the script under `set -e`
- Replaced with `synced=$((synced + 1))` which always returns 0
- Removed unnecessary `vercel env rm` since `--force` already handles overwrites

## Test plan
- [ ] Re-run the sync workflow — should complete all secrets without exit code 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)