### PR TITLE
feat: add rental cost note to property sidebar

### DIFF
--- a/src/components/__tests__/property-sidebar.test.tsx
+++ b/src/components/__tests__/property-sidebar.test.tsx
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+  }),
+}));
+
+vi.mock('@/contexts/auth-context', () => ({
+  useAuth: () => ({
+    user: null,
+    login: vi.fn(),
+  }),
+}));
+
+vi.mock('@/components/auth/custom-signup-dialog', () => ({
+  CustomSignupDialog: () => null,
+}));
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({
+    children,
+    ...props
+  }: {
+    children: React.ReactNode;
+    [key: string]: unknown;
+  }) => <button {...props}>{children}</button>,
+}));
+
+const { PropertySidebar } = await import('../property-sidebar');
+
+function makeProperty(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'test-1',
+    title: 'Test Property',
+    images: [],
+    handoverFee: 60000,
+    area: '渋谷区',
+    status: 'public' as const,
+    ...overrides,
+  };
+}
+
+describe('PropertySidebar', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('rental cost note', () => {
+    it('displays rental cost note below handover fee', () => {
+      const property = makeProperty({ handoverFee: 60000 });
+      render(<PropertySidebar property={property} />);
+
+      expect(
+        screen.getByText(
+          /賃貸の初期費用（敷金・礼金・仲介手数料等）は別途かかります/
+        )
+      ).toBeInTheDocument();
+    });
+
+    it('renders note with subdued styling', () => {
+      const property = makeProperty({ handoverFee: 50000 });
+      render(<PropertySidebar property={property} />);
+
+      const note = screen.getByText(
+        /賃貸の初期費用（敷金・礼金・仲介手数料等）は別途かかります/
+      );
+      expect(note.className).toContain('text-xs');
+      expect(note.className).toContain('text-muted-foreground');
+    });
+
+    it('displays handover fee amount', () => {
+      const property = makeProperty({ handoverFee: 60000 });
+      render(<PropertySidebar property={property} />);
+
+      expect(screen.getByText('¥60,000')).toBeInTheDocument();
+    });
+
+    it('displays rent when available', () => {
+      const property = makeProperty({ rent: 120000 });
+      render(<PropertySidebar property={property} />);
+
+      expect(screen.getByText('¥120,000/月')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/property-sidebar.tsx
+++ b/src/components/property-sidebar.tsx
@@ -40,6 +40,9 @@ export function PropertySidebar({ property }: PropertySidebarProps) {
             <span className="text-3xl font-semibold text-foreground">
               ¥{property.handoverFee.toLocaleString()}
             </span>
+            <p className="text-xs text-muted-foreground mt-2">
+              ※賃貸の初期費用（敷金・礼金・仲介手数料等）は別途かかります
+            </p>
           </div>
 
           {/* 家賃 */}


### PR DESCRIPTION
## Summary
- Add「※賃貸の初期費用（敷金・礼金・仲介手数料等）は別途かかります」note below the handover fee in `PropertySidebar` component on the listings detail page
- Prevents user confusion between tsumugi's handover fee and separate rental initial costs (deposit, key money, broker fees)
- Decision from Product Meeting #15

## Changes
- `src/components/property-sidebar.tsx` — Added rental cost disclaimer note (3 lines)
- `src/components/__tests__/property-sidebar.test.tsx` — New test file with 4 tests covering note presence and styling

## Test plan
- [x] Unit tests verify note displays with correct text
- [x] Unit tests verify subdued styling (text-xs text-muted-foreground)
- [x] Full test suite passes (814 tests, 77 files)
- [x] ESLint clean on changed files
- [x] TypeScript compilation successful

Closes tsumugi-5yku

🤖 Generated with [Claude Code](https://claude.com/claude-code)