### PR TITLE
feat: add isProCoordinated checkbox to listing form and API

### DIFF
--- a/src/app/api/properties/__tests__/route.test.ts
+++ b/src/app/api/properties/__tests__/route.test.ts
@@ -296,6 +296,58 @@ describe('POST /api/properties', () => {
     );
   });
 
+  it('passes isProCoordinated to DB when true', async () => {
+    const { POST } = await import('../route');
+    const { auth } = await import('@/lib/auth');
+    vi.mocked(auth.api.getSession).mockResolvedValue({
+      session: { id: 's1', userId: 'u1' },
+      user: { id: 'u1' },
+    } as any);
+    const { db } = await import('@/db');
+    const mockReturning = vi
+      .fn()
+      .mockResolvedValue([
+        { id: 'x', status: 'draft', isProCoordinated: true },
+      ]);
+    const mockValues = vi.fn().mockReturnValue({ returning: mockReturning });
+    vi.mocked(db.insert).mockReturnValue({ values: mockValues } as any);
+    const req = new Request('http://localhost/api/properties', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ title: 'テスト', isProCoordinated: true }),
+    });
+    await POST(req);
+    expect(mockValues).toHaveBeenCalledWith(
+      expect.objectContaining({ isProCoordinated: true })
+    );
+  });
+
+  it('defaults isProCoordinated to false when not provided', async () => {
+    const { POST } = await import('../route');
+    const { auth } = await import('@/lib/auth');
+    vi.mocked(auth.api.getSession).mockResolvedValue({
+      session: { id: 's1', userId: 'u1' },
+      user: { id: 'u1' },
+    } as any);
+    const { db } = await import('@/db');
+    const mockReturning = vi
+      .fn()
+      .mockResolvedValue([
+        { id: 'x', status: 'draft', isProCoordinated: false },
+      ]);
+    const mockValues = vi.fn().mockReturnValue({ returning: mockReturning });
+    vi.mocked(db.insert).mockReturnValue({ values: mockValues } as any);
+    const req = new Request('http://localhost/api/properties', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ title: 'テスト' }),
+    });
+    await POST(req);
+    expect(mockValues).toHaveBeenCalledWith(
+      expect.objectContaining({ isProCoordinated: false })
+    );
+  });
+
   it('accepts public status from client', async () => {
     const { POST } = await import('../route');
     const { auth } = await import('@/lib/auth');

--- a/src/app/api/properties/route.ts
+++ b/src/app/api/properties/route.ts
@@ -33,6 +33,7 @@ const createPropertySchema = z.object({
   furnitureDescription: z.string().optional(),
   story: z.string().optional(),
   conditions: z.string().optional(),
+  isProCoordinated: z.boolean().optional().default(false),
   handoverDetails: z
     .object({
       included: z.array(z.string()).optional(),
@@ -130,6 +131,7 @@ export async function POST(request: Request) {
         handoverDetails: data.handoverDetails,
         faq: data.faq,
         handoverHost: data.handoverHost,
+        isProCoordinated: data.isProCoordinated,
       })
       .returning();
 

--- a/src/app/listing/new/page.tsx
+++ b/src/app/listing/new/page.tsx
@@ -105,6 +105,7 @@ export default function NewListingPage() {
     { name: '', walkingMinutes: '' },
   ]);
   const [occupants, setOccupants] = useState<string>('');
+  const [isProCoordinated, setIsProCoordinated] = useState(false);
   const [uploadDialogOpen, setUploadDialogOpen] = useState(false);
   const [isUploading, setIsUploading] = useState(false);
   const [pendingPhotos, setPendingPhotos] = useState<string[]>([]);
@@ -235,6 +236,7 @@ export default function NewListingPage() {
                   furnitureCategory: id as 'sofa',
                 }))
               : undefined,
+          isProCoordinated,
           handoverDetails: {
             viewingAvailableFrom: formatDateRange(viewingDate, viewingEndDate),
             moveInAvailableFrom: formatDateRange(moveInDate, moveInEndDate),
@@ -639,6 +641,18 @@ export default function NewListingPage() {
                     ))}
                   </div>
                 </div>
+                <label className="flex items-center gap-3 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={isProCoordinated}
+                    onChange={(e) => setIsProCoordinated(e.target.checked)}
+                    className="h-4 w-4 rounded border-border accent-coral"
+                    data-testid="pro-coordinated-checkbox"
+                  />
+                  <span className="text-sm">
+                    プロのコーディネーターと連携していますか？
+                  </span>
+                </label>
               </div>
             </div>
           )}


### PR DESCRIPTION
## Summary

- Add `isProCoordinated` boolean checkbox to the property registration form (NewListingPage, Step 4: 費用と物件情報)
- Wire the field through the API route Zod schema and db.insert() to persist to the database
- Label: 「プロのコーディネーターと連携していますか？」
- Defaults to `false` when not provided (matches DB schema default)

## Changes

| File | Change |
|------|--------|
| `src/app/listing/new/page.tsx` | Add state, checkbox UI in Step 4, include in saveListing payload |
| `src/app/api/properties/route.ts` | Add `isProCoordinated` to Zod schema + db.insert() values |
| `src/app/api/properties/__tests__/route.test.ts` | Add 2 tests: true case + default false case |

## Context

Decided in Product Meeting #15. MVP stage: data collection only. Display features (F-901-903) are Post-MVP.

The DB schema column (`is_pro_coordinated`) and migration already existed from a previous PR. This PR completes the integration by:
1. Adding the checkbox to the main listing form (NewListingPage)
2. Wiring the API route to accept and persist the value

## Test plan

- [x] 2 new API route tests pass (isProCoordinated true + default false)
- [x] All 812 existing tests pass
- [x] TypeScript compilation clean (no new errors)
- [x] Lint passes (no new warnings)
- [ ] CI checks pass

Refs: TSU-287, tsumugi-7kd3

🤖 Generated with [Claude Code](https://claude.com/claude-code)