### PR TITLE
fix: use printf instead of echo in vercel env sync

### DIFF
--- a/scripts/sync-env-to-vercel.sh
+++ b/scripts/sync-env-to-vercel.sh
@@ -57,7 +57,7 @@ for name in "${!ENV_VARS[@]}"; do
   fi
 
   for target in "${TARGETS[@]}"; do
-    if echo "$value" | vercel env add "$name" "$target" --token="$VERCEL_TOKEN" --force; then
+    if printf "%s" "$value" | vercel env add "$name" "$target" --token="$VERCEL_TOKEN" --force; then
       echo "OK:   $name → $target"
       synced=$((synced + 1))
     else


### PR DESCRIPTION
## Summary
- `echo "$value"` appends a newline when piping to `vercel env add`, causing all synced env vars to include a literal `\n` suffix
- This corrupted R2 credentials (causing `ERR_INVALID_CHAR` in S3 authorization headers), DATABASE_URL, BETTER_AUTH_SECRET, and other secrets
- Fix: use `printf "%s" "$value"` which does not append a trailing newline

## Test plan
- [ ] Verify `sync-env-to-vercel.sh` syncs values without trailing `\n`
- [ ] Confirm production uploads work after redeployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)