### PR TITLE
feat: add Agent Teams parallel support to /pr command

### DIFF
--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -1,6 +1,12 @@
+---
+description: Create Pull Request. Supports Agent Teams for parallel multi-PR workflows.
+allowed-tools: Bash, Read, Edit, Write, Grep, Glob, Task
+---
+
 # Create Pull Request
 
 Create focused pull requests with changes grouped logically and limited to 200 lines each.
+When multiple independent groups exist and Agent Teams is available, spawns parallel teammates for simultaneous PR creation.
 
 ## Step 1: Analyze Changes
 
@@ -18,6 +24,8 @@ Analyze all changes and group them by:
 
 For each group, calculate total line changes (additions + deletions).
 
+Mark inter-group dependencies: does group B require group A's changes to build/work?
+
 ## Step 3: Split if Needed
 
 If any group exceeds 200 lines:
@@ -26,23 +34,28 @@ If any group exceeds 200 lines:
 - Each PR should be independently reviewable
 - Maintain dependency order (base changes first)
 
-Present groups to user:
+Present groups to user with dependency info:
 
 ```
-Group 1: feat: add location picker (156 lines)
+Group 1: feat: add location picker (156 lines) [independent]
   - src/components/location-picker.tsx (+120, -0)
   - src/lib/geocoding.ts (+36, -0)
 
-Group 2: fix: improve date range validation (89 lines)
+Group 2: fix: improve date range validation (89 lines) [independent]
   - src/components/date-range-picker.tsx (+45, -12)
   - src/lib/date-utils.ts (+32, -0)
+
+Group 3: feat: use location in search (45 lines) [depends on Group 1]
+  - src/components/search.tsx (+30, -15)
+
+Strategy: Groups 1 & 2 in parallel, then Group 3 after Group 1 merges.
 ```
 
 Ask user to confirm or adjust groupings.
 
-## Step 4: Run Tests
+## Step 4: Run Verification
 
-Before pushing, verify all tests pass:
+Before creating any PRs, verify the full codebase passes:
 
 1. **Run test suite**:
 
@@ -62,22 +75,39 @@ Before pushing, verify all tests pass:
    bun run lint
    ```
 
-4. **Run build** (if applicable):
+4. **Run build**:
    ```bash
    bun run build
    ```
 
-If any test fails:
+If any check fails:
 
 - **STOP** - Do not proceed with PR creation
-- Report the failing tests to user
+- Report the failing checks to user
 - Ask user how to proceed (fix issues or skip PR)
 
-## Step 5: Create PRs
+## Step 5: Route — Single vs Parallel
+
+**Decision point based on group count and Agent Teams availability:**
+
+- **1 group** → Step 6A (single PR, sequential)
+- **2+ independent groups, Agent Teams available** → Step 6B (parallel via Agent Teams)
+- **2+ groups, Agent Teams unavailable or groups have dependencies** → Step 6A sequentially, respecting dependency order
+
+To check Agent Teams availability:
+
+- The env var `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` must be set
+- Must be in an interactive CLI session (not CI/headless)
+
+If Agent Teams is available but all groups have chain dependencies (each depends on the previous), fall back to Step 6A sequential.
+
+---
+
+## Step 6A: Single PR Flow (Sequential)
 
 **IMPORTANT**: You MUST automatically create pull requests using `gh pr create`. DO NOT just push branches and expect the user to create PRs manually.
 
-For each approved group:
+For each approved group (in dependency order):
 
 1. **Create branch** (if needed):
 
@@ -127,59 +157,203 @@ For each approved group:
    )"
    ```
 
-6. **Report PR URL and status** after creation
-
-## Step 6: Wait for CI and Merge
-
-After PR is created:
-
-1. **Monitor CI checks**:
+6. **Monitor CI and merge** (per PR):
 
    ```bash
    gh pr checks <pr-number>
-   ```
-
-2. **Wait for all checks to pass** - Do NOT proceed if any check fails
-
-3. **Merge PR and delete remote branch**:
-
-   ```bash
+   # Wait for all checks to pass
    gh pr merge <pr-number> --squash --delete-branch
    ```
 
-   This deletes the **remote branch** on GitHub.
-
-4. **Clean up local workspace**:
+7. **Clean up local workspace**:
 
    ```bash
-   # Switch to main (if not already there)
    git checkout main
-
-   # Pull latest changes
    git pull origin main
-
-   # Delete local feature branch (only if it exists)
    if git show-ref --verify --quiet refs/heads/<feature-branch-name>; then
      git branch -d <feature-branch-name>
    fi
    ```
 
-   This deletes the **local branch** (only if it exists).
+8. If more groups remain, return to substep 1 for the next group.
 
-**Result**: Both remote and local branches are deleted.
+---
 
-**Note**: The existence check prevents errors when the branch has already been deleted.
+## Step 6B: Parallel PR Flow (Agent Teams)
+
+When 2+ independent groups exist and Agent Teams is available, spawn teammates for parallel execution.
+
+### Phase 1: Prepare Worktrees
+
+Create one worktree per independent group:
+
+```bash
+for each group {n}:
+  bun run worktree:create pr-group-{n}
+```
+
+Copy the relevant files for each group into its worktree (each worktree starts from main, so the changed files from the current branch need to be applied).
+
+For each worktree:
+
+```bash
+# From the current branch, checkout only this group's files into the worktree
+cd /workspace/.worktrees/pr-group-{n}
+git checkout <current-branch> -- <file1> <file2> ...
+```
+
+### Phase 2: Spawn PR Team
+
+Create an agent team with one teammate per independent group. Use **delegate mode**.
+
+```
+Create an agent team for parallel PR creation.
+Spawn {N} teammates, one per PR group below.
+Use delegate mode -- coordinate only, do not implement yourself.
+
+Groups:
+1. Teammate "pr-group-1": {type}: {description} ({line_count} lines)
+   Worktree: /workspace/.worktrees/pr-group-1
+   Files: {file1}, {file2}, ...
+
+2. Teammate "pr-group-2": {type}: {description} ({line_count} lines)
+   Worktree: /workspace/.worktrees/pr-group-2
+   Files: {file1}, {file2}, ...
+
+[... up to 5 groups]
+```
+
+#### Teammate Prompt
+
+````
+You are creating a PR for one group of changes in the tsumugi project (Next.js/TypeScript/Bun).
+
+## Your Group
+**Title:** {type}: {description}
+**Files:** {file list}
+**Line count:** {additions + deletions}
+
+## Your Worktree
+Work ONLY in: /workspace/.worktrees/pr-group-{n}
+cd /workspace/.worktrees/pr-group-{n}
+
+## Steps (follow exactly)
+1. Verify the changed files are present: `git diff --stat origin/main`
+2. Run verification in your worktree:
+   - `bun run test:run`
+   - `bun run lint`
+   - `bunx tsc --noEmit`
+   - `bun run build`
+   If any fail, message the lead with the error.
+3. Stage explicitly: `git add <files>` (NEVER `git add .` or `-A`)
+4. Commit: `git commit -m "{type}: {description}"`
+5. Push: `git push -u origin HEAD`
+6. Create PR:
+   ```bash
+   gh pr create --title "{type}: {description}" --body "$(cat <<'EOF'
+   ## Summary
+   <2-4 bullet points>
+
+   ## Changes
+   <bulleted list>
+
+   ## Test Plan
+   - [ ] <step 1>
+   - [ ] <step 2>
+
+   Generated with Claude Code
+   EOF
+   )"
+````
+
+7. CI Loop (max 5 iterations):
+   - `gh pr checks <pr-number>`
+   - If fail: `gh run view <id> --log-failed` -> fix -> push -> repeat
+8. Message the lead when done with: group number, PR URL, CI status
+
+````
+
+### Phase 3: Coordinate
+
+The lead monitors teammate progress:
+
+- Track each teammate's PR URL and CI status
+- If a teammate hits CI failure after 5 iterations: mark as blocked, continue with others
+- When all independent teammates finish: proceed to merge
+
+### Phase 4: Merge All
+
+Merge all successful PRs:
+
+```bash
+# For each PR (no dependency order needed -- they're independent)
+gh pr merge <pr-number> --squash --delete-branch
+````
+
+### Phase 5: Handle Dependent Groups
+
+If there are groups that depend on now-merged groups:
+
+1. Pull latest main
+2. Repeat Step 6B Phase 1-4 for the next batch of unblocked groups
+3. Continue until all groups are processed
+
+### Phase 6: Worktree Cleanup
+
+**3 SEPARATE Bash calls per worktree (CRITICAL -- never chain):**
+
+```bash
+# Call 1: Ensure CWD is safe
+cd /workspace
+
+# Call 2: Remove worktree
+git worktree remove /workspace/.worktrees/pr-group-{n} --force
+
+# Call 3: Clean up branches and pull
+git branch -D pr-group-{n} 2>/dev/null; git pull origin main
+```
+
+### Phase 7: Dismiss Team
+
+Dismiss the agent team after all PRs are merged and worktrees cleaned up.
+
+---
+
+## Step 7: Report
+
+Print summary:
+
+```
+## PR Summary
+| # | Group | PR | Status | Lines |
+|---|-------|----|--------|-------|
+| 1 | feat: add location picker | #142 | merged | 156 |
+| 2 | fix: date range validation | #143 | merged | 89 |
+
+Mode: {sequential | parallel (Agent Teams)}
+Total PRs: {N} | Merged: {X} | Failed: {Y}
+```
+
+## Step 8: Task Closure
+
+After all PRs are merged, close related tasks:
+
+```bash
+source .env.local && bd close <id>
+./scripts/linear-done.sh TSU-xxx
+```
+
+Update DASHBOARD.md if applicable.
 
 ## Rules
 
 - **ALWAYS create PRs automatically** - Never just push and tell user to create PR manually
-- **All tests must pass** before pushing
-- **Type check must pass** before pushing
-- **Lint must pass** before pushing
-- **Build must succeed** before pushing
+- **All checks must pass** before pushing (test, lint, type check, build)
 - **Max 200 lines per PR** (additions + deletions)
 - **Title MUST use conventional commits** format
 - **One logical change per PR** - independently reviewable
 - **No uncommitted changes** - commit or stash first
-- **Dependencies first** - if PR B depends on PR A, create A first
+- **Dependencies first** - if PR B depends on PR A, merge A first
 - **Use `gh pr create`** - Not just `git push`
+- **Parallel when possible** - Use Agent Teams for 2+ independent groups
+- **Sequential fallback** - Always works, even without Agent Teams


### PR DESCRIPTION
## Summary

- Enhances `/pr` command to spawn parallel Agent Teams teammates when multiple independent change groups are detected
- Single-group PRs continue using the fast sequential path (no overhead added)
- Adds dependency tracking between groups and a routing step to decide single vs parallel execution

## Changes

- Added frontmatter with `description` and `allowed-tools`
- Added inter-group dependency tracking in Step 2-3 (`[independent]` / `[depends on Group N]`)
- Added Step 5: routing decision (single → 6A sequential, multi-independent → 6B parallel, dependencies → 6A sequential)
- Added Step 6B: full Agent Teams parallel flow (worktree prep → spawn teammates → coordinate → merge → handle dependent groups → cleanup)
- Added Step 7: summary report with mode indicator
- Added Step 8: task closure (Beads + Linear)
- Consolidated verification rules in Rules section

## Test Plan

- [ ] Run `/pr` with a single group of changes — should use sequential flow (6A)
- [ ] Run `/pr` with 2+ independent groups + Agent Teams enabled — should spawn parallel teammates (6B)
- [ ] Run `/pr` with dependent groups — should fall back to sequential (6A) in dependency order
- [ ] Run `/pr` without Agent Teams env var — should always use sequential (6A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)