### PR TITLE
chore: reorder settings.json keys

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,6 +10,7 @@
       "WebSearch"
     ]
   },
+  "enableAllProjectMcpServers": true,
   "hooks": {
     "SessionStart": [
       {
@@ -30,7 +31,6 @@
       }
     ]
   },
-  "enableAllProjectMcpServers": true,
   "enabledPlugins": {
     "frontend-design@claude-plugins-official": true,
     "ralph-loop@claude-plugins-official": true,


### PR DESCRIPTION
## Summary
- Moved `enableAllProjectMcpServers` key to a more logical position in `.claude/settings.json`
- No functional change, purely cosmetic reorder

## Changes
- `.claude/settings.json`: Reordered `enableAllProjectMcpServers` to appear before `hooks` section

## Test Plan
- [x] No functional change — key ordering in JSON is semantically irrelevant

Generated with Claude Code