### PR TITLE
fix: use non-bare git init in devcontainer setup

### DIFF
--- a/scripts/devcontainer-setup.sh
+++ b/scripts/devcontainer-setup.sh
@@ -15,11 +15,12 @@ if [ -f .git ] && ! git rev-parse --git-dir >/dev/null 2>&1; then
   echo "Detected broken git submodule reference, initializing container-local git..."
   GIT_LOCAL="/home/bun/.tsumugi-git"
 
-  git init --bare "$GIT_LOCAL"
+  git init "$GIT_LOCAL"
   git --git-dir="$GIT_LOCAL" remote add origin git@github.com:kokiebisu/tsumugi.git 2>/dev/null || true
   git --git-dir="$GIT_LOCAL" config user.email "kokiebisu@icloud.com"
   git --git-dir="$GIT_LOCAL" config user.name "neko"
   git --git-dir="$GIT_LOCAL" config core.worktree /workspace
+  git --git-dir="$GIT_LOCAL" config core.bare false
 
   # Fetch from remote (SSH keys are mounted from host)
   git --git-dir="$GIT_LOCAL" fetch origin 2>/dev/null || {


### PR DESCRIPTION
## Summary
- Changed `git init --bare` to `git init` in devcontainer setup script
- Added explicit `core.bare false` config to ensure correct git behavior
- Fixes git operations that require a working tree in the devcontainer

## Changes
- `scripts/devcontainer-setup.sh`: Replace `--bare` init with regular init + `core.bare false`

## Test Plan
- [ ] Verify devcontainer starts correctly with updated git init
- [ ] Verify git operations (fetch, checkout, status) work in devcontainer

Generated with Claude Code