### PR TITLE
fix: use non-bare git init in devcontainer setup

### DIFF
--- a/scripts/devcontainer-setup.sh
+++ b/scripts/devcontainer-setup.sh
@@ -15,11 +15,12 @@ if [ -f .git ] && ! git rev-parse --git-dir >/dev/null 2>&1; then
   echo "Detected broken git submodule reference, initializing container-local git..."
   GIT_LOCAL="/home/bun/.tsumugi-git"
 
-  git init --bare "$GIT_LOCAL"
+  git init "$GIT_LOCAL"
   git --git-dir="$GIT_LOCAL" remote add origin git@github.com:kokiebisu/tsumugi.git 2>/dev/null || true
   git --git-dir="$GIT_LOCAL" config user.email "kokiebisu@icloud.com"
   git --git-dir="$GIT_LOCAL" config user.name "neko"
   git --git-dir="$GIT_LOCAL" config core.worktree /workspace
+  git --git-dir="$GIT_LOCAL" config core.bare false
 
   # Fetch from remote (SSH keys are mounted from host)
   git --git-dir="$GIT_LOCAL" fetch origin 2>/dev/null || {


### PR DESCRIPTION
## Summary
- Fixed devcontainer setup script using `git init --bare` which contradicts the subsequent `core.worktree` configuration
- Changed to `git init` (non-bare) and added explicit `core.bare false` setting

## Changes
- `scripts/devcontainer-setup.sh`: Replaced `git init --bare` with `git init`
- `scripts/devcontainer-setup.sh`: Added `git config core.bare false` for explicit non-bare configuration

## Test Plan
- [ ] Verify devcontainer starts correctly with the updated script
- [ ] Confirm git operations work in the container workspace

Generated with Claude Code