### PR TITLE
ci: auto-merge autonomous state PRs

### DIFF
--- a/.github/workflows/autonomous-developer.yml
+++ b/.github/workflows/autonomous-developer.yml
@@ -318,6 +318,14 @@ jobs:
             echo "WARNING: Failed to set ci status — PR may need manual merge"
           }
 
+          # Auto-merge the state PR (data-only, safe to merge immediately)
+          PR_NUMBER=$(gh pr view "$STATE_BRANCH" --json number --jq '.number' 2>/dev/null || echo "")
+          if [ -n "$PR_NUMBER" ]; then
+            gh pr merge "$PR_NUMBER" --squash --delete-branch || {
+              echo "WARNING: Failed to auto-merge state PR #$PR_NUMBER"
+            }
+          fi
+
           # Return to the original branch for subsequent steps
           git checkout main 2>/dev/null || true
           git pull origin main 2>/dev/null || true


### PR DESCRIPTION
## Summary
- Autonomous developer workflow creates data-only state PRs (`.beads/` + `state.json`) but never merges them, causing pile-up
- Added `gh pr merge --squash --delete-branch` after PR creation to auto-merge immediately
- Cleaned up 5 stale state PRs (#384, #406, #414, #418, #419)

## Test plan
- [ ] Next autonomous developer run should create and immediately merge its state PR
- [ ] No manual intervention needed for state updates going forward

🤖 Generated with [Claude Code](https://claude.com/claude-code)