### PR TITLE
fix: proxy R2 images through API when public URL not configured

### DIFF
--- a/src/app/api/images/[...path]/route.ts
+++ b/src/app/api/images/[...path]/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server';
+import { getImage } from '@/lib/storage';
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ path: string[] }> }
+) {
+  const { path } = await params;
+  const key = path.join('/');
+
+  const result = await getImage(key);
+  if (!result) {
+    return new NextResponse(null, { status: 404 });
+  }
+
+  return new NextResponse(result.body, {
+    headers: {
+      'Content-Type': result.contentType,
+      'Cache-Control': 'public, max-age=31536000, immutable',
+    },
+  });
+}

--- a/src/lib/__tests__/storage.test.ts
+++ b/src/lib/__tests__/storage.test.ts
@@ -17,6 +17,12 @@ vi.mock('@aws-sdk/client-s3', () => {
         this.input = input;
       }
     },
+    GetObjectCommand: class MockGetObjectCommand {
+      input: unknown;
+      constructor(input: unknown) {
+        this.input = input;
+      }
+    },
   };
 });
 
@@ -84,7 +90,7 @@ describe('storage', () => {
       expect(url).toBe('https://cdn.example.com/uploads/test-uuid.png');
     });
 
-    it('returns R2 storage URL as fallback', async () => {
+    it('returns proxy URL as fallback when R2_PUBLIC_URL not set', async () => {
       vi.stubEnv('S3_ENDPOINT', '');
       vi.stubEnv('R2_PUBLIC_URL', '');
       vi.stubEnv('R2_ACCOUNT_ID', 'abc123');
@@ -94,9 +100,7 @@ describe('storage', () => {
 
       const { uploadImage } = await import('../storage');
       const url = await uploadImage(Buffer.from('test'), 'image/png');
-      expect(url).toBe(
-        'https://abc123.r2.cloudflarestorage.com/tsumugi/uploads/test-uuid.png'
-      );
+      expect(url).toBe('/api/images/uploads/test-uuid.png');
     });
   });
 

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,4 +1,8 @@
-import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
+import {
+  S3Client,
+  PutObjectCommand,
+  GetObjectCommand,
+} from '@aws-sdk/client-s3';
 import { randomUUID } from 'crypto';
 
 const S3_ENDPOINT = process.env.S3_ENDPOINT ?? '';
@@ -56,7 +60,26 @@ function getPublicUrl(key: string): string {
   if (R2_PUBLIC_URL) {
     return `${R2_PUBLIC_URL}/${key}`;
   }
-  return `https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com/${BUCKET_NAME}/${key}`;
+  // Proxy through Next.js API — the S3 API endpoint requires authentication
+  return `/api/images/${key}`;
+}
+
+export async function getImage(
+  key: string
+): Promise<{ body: ReadableStream; contentType: string } | null> {
+  const client = getS3Client();
+  try {
+    const response = await client.send(
+      new GetObjectCommand({ Bucket: BUCKET_NAME, Key: key })
+    );
+    if (!response.Body) return null;
+    return {
+      body: response.Body.transformToWebStream() as ReadableStream,
+      contentType: response.ContentType ?? 'application/octet-stream',
+    };
+  } catch {
+    return null;
+  }
 }
 
 export async function uploadPdf(


### PR DESCRIPTION
## Summary
- When `R2_PUBLIC_URL` is not set, uploaded images were invisible in production because `getPublicUrl()` returned the S3 API endpoint (`https://{account_id}.r2.cloudflarestorage.com/...`) which requires authentication — browsers can't load these in `<img>` tags
- Added `/api/images/[...path]` proxy route that fetches images from R2 with server-side auth and serves them with immutable cache headers
- Updated `getPublicUrl()` fallback to use `/api/images/{key}` instead of the unauthenticated S3 URL

## Test plan
- [ ] Upload images in listing creation (Step 2) — verify they display correctly
- [ ] Verify images still work when `R2_PUBLIC_URL` is set (direct URL path)
- [ ] Verify images still work in local dev with LocalStack (`/storage/` path)
- [ ] Unit tests pass (`bun run test:run -- src/lib/__tests__/storage.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)