### PR TITLE
fix: remove max-w-md constraint from date picker container

### DIFF
--- a/src/app/listing/new/page.tsx
+++ b/src/app/listing/new/page.tsx
@@ -650,7 +650,7 @@ export default function NewListingPage() {
                 内見や引き継ぎの日程はマッチング後にメッセージで調整できます
               </p>
 
-              <div className="w-full max-w-md">
+              <div className="w-full">
                 <SingleDatePicker
                   selectedDate={moveOutDate}
                   endDate={null}


### PR DESCRIPTION
## Summary
- Remove `max-w-md` (448px) constraint from step 5 date picker container
- Add `singleOnly` mode to `SingleDatePicker` — clicking another date now replaces the selection instead of trying to create a range
- Fix misleading subtitle "この日以降（終了日を追加で選択可能）" showing for move-out date

## Test plan
- [ ] Step 5 calendar displays correctly at full width
- [ ] Clicking a different date after initial selection replaces it
- [ ] No range-related subtitles appear after selecting move-out date
- [ ] Clicking the same date again deselects it

🤖 Generated with [Claude Code](https://claude.com/claude-code)