### PR TITLE
fix: normalize old R2 URLs to use image proxy

### DIFF
--- a/src/app/listing/page.tsx
+++ b/src/app/listing/page.tsx
@@ -17,6 +17,7 @@ import {
   Home,
   AlertTriangle,
 } from 'lucide-react';
+import { normalizeImageUrl } from '@/lib/utils';
 import { InquiryList } from '@/components/admin/inquiry-list';
 import { ConsentBadge } from '@/components/consent-badge';
 
@@ -118,7 +119,9 @@ function ListingCard({
   onDelete: (id: string) => void;
 }) {
   const [showMenu, setShowMenu] = useState(false);
-  const firstPhoto = listing.images?.[0];
+  const firstPhoto = listing.images?.[0]
+    ? normalizeImageUrl(listing.images[0])
+    : undefined;
   const displayStatus = listing.status === 'public' ? 'published' : 'draft';
   const consentStatus = listing.landlordConsent?.status;
 

--- a/src/app/listings/[id]/inquiry/page.tsx
+++ b/src/app/listings/[id]/inquiry/page.tsx
@@ -5,6 +5,7 @@ import { Footer } from '@/components/footer';
 import { InquiryForm } from '@/components/inquiry-form';
 import { getPropertyById, getPublicProperties } from '@/lib/data';
 import { ArrowLeft, Info } from 'lucide-react';
+import { normalizeImageUrl } from '@/lib/utils';
 
 interface InquiryPageProps {
   params: Promise<{ id: string }>;
@@ -58,7 +59,11 @@ export default async function InquiryPage({ params }: InquiryPageProps) {
           <div className="mb-8 flex gap-4 rounded-xl border border-border bg-background p-4">
             <div className="h-20 w-20 shrink-0 overflow-hidden rounded-lg">
               <img
-                src={property.images[0] || '/placeholder.svg'}
+                src={
+                  property.images[0]
+                    ? normalizeImageUrl(property.images[0])
+                    : '/placeholder.svg'
+                }
                 alt={property.title}
                 className="h-full w-full object-cover"
               />

--- a/src/components/image-gallery.tsx
+++ b/src/components/image-gallery.tsx
@@ -3,13 +3,15 @@
 import { useState } from 'react';
 import Image from 'next/image';
 import { ChevronLeft, ChevronRight, X } from 'lucide-react';
+import { normalizeImageUrl } from '@/lib/utils';
 
 interface ImageGalleryProps {
   images: string[];
   title: string;
 }
 
-export function ImageGallery({ images, title }: ImageGalleryProps) {
+export function ImageGallery({ images: rawImages, title }: ImageGalleryProps) {
+  const images = rawImages.map(normalizeImageUrl);
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [loadedImages, setLoadedImages] = useState<Set<number>>(new Set());

--- a/src/components/progressive-image-gallery.tsx
+++ b/src/components/progressive-image-gallery.tsx
@@ -6,6 +6,7 @@ import { useAuth } from '@/contexts/auth-context';
 import { ImageGallery } from '@/components/image-gallery';
 import { Button } from '@/components/ui/button';
 import { Lock, Eye, User } from 'lucide-react';
+import { normalizeImageUrl } from '@/lib/utils';
 
 interface ProgressiveImageGalleryProps {
   images: string[];
@@ -22,10 +23,11 @@ interface ProgressiveImageGalleryProps {
  * - 内見調整フェーズ: 完全公開（住所詳細等）← これは別コンポーネントで管理
  */
 export function ProgressiveImageGallery({
-  images,
+  images: rawImages,
   title,
   isLoggedIn: isLoggedInOverride,
 }: ProgressiveImageGalleryProps) {
+  const images = rawImages.map(normalizeImageUrl);
   const { user } = useAuth();
   const isLoggedIn = isLoggedInOverride ?? !!user;
   const [showLoginPrompt, setShowLoginPrompt] = useState(false);

--- a/src/components/property-card.tsx
+++ b/src/components/property-card.tsx
@@ -7,7 +7,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { Heart, ChevronLeft, ChevronRight } from 'lucide-react';
 import type { Property } from '@/lib/data';
-import { isUrgentMoveIn } from '@/lib/utils';
+import { isUrgentMoveIn, normalizeImageUrl } from '@/lib/utils';
 import { UrgentMoveInBadge } from '@/components/urgent-move-in-badge';
 import { ConsentBadge } from '@/components/consent-badge';
 import { StarRating } from '@/components/ui/star-rating';
@@ -57,7 +57,10 @@ export function PropertyCard({ property }: PropertyCardProps) {
     setIsLiked(!isLiked);
   };
 
-  const currentImageSrc = property.images[currentImage] || '/placeholder.svg';
+  const currentImageSrc =
+    (property.images[currentImage] &&
+      normalizeImageUrl(property.images[currentImage])) ||
+    '/placeholder.svg';
 
   return (
     <Link href={`/listings/${property.id}`} className="group block">

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -5,6 +5,18 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
+const R2_URL_RE = /^https:\/\/[a-f0-9]+\.r2\.cloudflarestorage\.com\//;
+
+/**
+ * Rewrite old R2 S3 API endpoint URLs to use the /api/images proxy.
+ * URLs already using the proxy, R2_PUBLIC_URL, or local /storage/ are returned as-is.
+ */
+export function normalizeImageUrl(url: string): string {
+  if (!R2_URL_RE.test(url)) return url;
+  const path = new URL(url).pathname.slice(1);
+  return `/api/images/${path}`;
+}
+
 /**
  * 退去日までの残り日数を計算
  */


### PR DESCRIPTION
## Summary
- Existing images in the database have direct R2 S3 API endpoint URLs (`https://{id}.r2.cloudflarestorage.com/...`) which return 400 Bad Request in the browser
- Added `normalizeImageUrl()` utility that rewrites these to `/api/images/` proxy URLs (from PR #425)
- Applied normalization in all image rendering components: `ImageGallery`, `ProgressiveImageGallery`, `PropertyCard`, listing management page, and inquiry page

## Test plan
- [ ] Verify existing listings with old R2 URLs now display images correctly
- [ ] Verify new uploads still work (URLs should already be `/api/images/` format)
- [ ] Verify `R2_PUBLIC_URL` direct URLs still work (not rewritten)
- [ ] Verify local dev with `/storage/` URLs still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)