### PR TITLE
chore: rename package.json to sumitsugi

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "my-v0-project",
+  "name": "sumitsugi",
   "version": "0.1.0",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary

- Rename package.json `name` field from `my-v0-project` to `sumitsugi`
- Missed in the initial rebranding PR (#432) since the original name didn't contain "tsumugi"

## Changes

- `package.json`: `"name": "my-v0-project"` → `"name": "sumitsugi"`

## Test Plan

- [x] `bun run build` passes
- [x] 1 file, 1 line change — no logic impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)