### PR TITLE
ci: unify auth tokens and migrate workflows to Claude Code CLI

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -35,7 +35,7 @@ jobs:
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_code_oauth_token: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,7 +34,7 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@v1
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_code_oauth_token: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |

--- a/.github/workflows/daily-standup.yml
+++ b/.github/workflows/daily-standup.yml
@@ -64,9 +64,12 @@ jobs:
           echo "tasks_open=$TASKS_OPEN" >> "$GITHUB_OUTPUT"
           echo "tasks_blocked=$TASKS_BLOCKED" >> "$GITHUB_OUTPUT"
 
+      - name: Install Claude Code CLI
+        run: npm install -g @anthropic-ai/claude-code
+
       - name: Generate standup report
         env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
           REPORT_DATE: ${{ steps.metrics.outputs.today }}
           TASKS_DONE: ${{ steps.metrics.outputs.tasks_done }}
           TASKS_OPEN: ${{ steps.metrics.outputs.tasks_open }}
@@ -109,13 +112,7 @@ jobs:
           Recent Commits: $COMMITS
           Failed Runs: $FAILED_RUNS"
 
-          RESPONSE=$(curl -s https://api.anthropic.com/v1/messages \
-            -H "Content-Type: application/json" \
-            -H "x-api-key: $ANTHROPIC_API_KEY" \
-            -H "anthropic-version: 2023-06-01" \
-            -d "{\"model\": \"claude-sonnet-4-5-20250929\", \"max_tokens\": 2048, \"messages\": [{\"role\": \"user\", \"content\": $(echo "$PROMPT" | jq -Rs .)}]}")
-
-          REPORT=$(echo "$RESPONSE" | jq -r '.content[0].text // "Report generation failed"')
+          REPORT=$(echo "$PROMPT" | claude -p --model claude-sonnet-4-5-20250929 2>/dev/null || echo "Report generation failed")
 
           mkdir -p docs/team/standups
           echo "$REPORT" > "docs/team/standups/$REPORT_DATE.md"

--- a/.github/workflows/requirements-audit.yml
+++ b/.github/workflows/requirements-audit.yml
@@ -37,9 +37,12 @@ jobs:
           # Existing tasks
           cat .beads/issues.jsonl 2>/dev/null | jq -s '[.[] | {id, title, status}]' > /tmp/tasks.json 2>/dev/null || echo "[]" > /tmp/tasks.json
 
+      - name: Install Claude Code CLI
+        run: npm install -g @anthropic-ai/claude-code
+
       - name: Run Claude Audit
         env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
         run: |
           REQUIREMENTS=$(cat /tmp/requirements.md)
           BUSINESS=$(cat /tmp/business.md)
@@ -63,13 +66,8 @@ jobs:
           Existing tasks (avoid duplicates):
           $TASKS"
 
-          RESPONSE=$(curl -s https://api.anthropic.com/v1/messages \
-            -H "Content-Type: application/json" \
-            -H "x-api-key: $ANTHROPIC_API_KEY" \
-            -H "anthropic-version: 2023-06-01" \
-            -d "{\"model\": \"claude-sonnet-4-20250514\", \"max_tokens\": 4096, \"messages\": [{\"role\": \"user\", \"content\": $(echo "$PROMPT" | jq -Rs .)}]}")
-
-          echo "$RESPONSE" | jq -r '.content[0].text // "{\"error\": \"failed\"}"' > /tmp/audit.json
+          RESPONSE=$(echo "$PROMPT" | claude -p --model claude-sonnet-4-5-20250929 2>/dev/null || echo '{"error": "failed"}')
+          echo "$RESPONSE" > /tmp/audit.json
           cat /tmp/audit.json
 
       - name: Create tasks and PR

--- a/.github/workflows/sync-vercel-env.yml
+++ b/.github/workflows/sync-vercel-env.yml
@@ -46,7 +46,7 @@ jobs:
           R2_PUBLIC_URL: ${{ secrets.R2_PUBLIC_URL }}
           RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
           EMAIL_FROM: ${{ secrets.EMAIL_FROM }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
           STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
           STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
           NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY }}

--- a/.github/workflows/weekly-retrospective.yml
+++ b/.github/workflows/weekly-retrospective.yml
@@ -80,9 +80,12 @@ jobs:
           echo "ci_total=$CI_TOTAL" >> "$GITHUB_OUTPUT"
           echo "ci_success=$CI_SUCCESS" >> "$GITHUB_OUTPUT"
 
+      - name: Install Claude Code CLI
+        run: npm install -g @anthropic-ai/claude-code
+
       - name: Generate retrospective
         env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
           WEEK_START: ${{ steps.metrics.outputs.week_start }}
           WEEK_END: ${{ steps.metrics.outputs.week_end }}
           PRS_MERGED: ${{ steps.metrics.outputs.prs_merged }}
@@ -136,13 +139,7 @@ jobs:
           PRs Created: $PRS_CREATED_DATA
           Failed Runs: $FAILED_RUNS_DATA"
 
-          RESPONSE=$(curl -s https://api.anthropic.com/v1/messages \
-            -H "Content-Type: application/json" \
-            -H "x-api-key: $ANTHROPIC_API_KEY" \
-            -H "anthropic-version: 2023-06-01" \
-            -d "{\"model\": \"claude-sonnet-4-5-20250929\", \"max_tokens\": 3000, \"messages\": [{\"role\": \"user\", \"content\": $(echo "$PROMPT" | jq -Rs .)}]}")
-
-          REPORT=$(echo "$RESPONSE" | jq -r '.content[0].text // "Report generation failed"')
+          REPORT=$(echo "$PROMPT" | claude -p --model claude-sonnet-4-5-20250929 2>/dev/null || echo "Report generation failed")
 
           mkdir -p docs/team/retrospectives
           echo "$REPORT" > "docs/team/retrospectives/$WEEK_END.md"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ Airbnb風クリーンUI / アクセント: `#FF5A5F` / Lucide React / shadcn/ui 
 ## GitHub Actions (CRITICAL)
 
 Claude Code CLI (`claude -p`) を使用。Anthropic SDKはOAuthトークン非対応。
-Secret: `ANTHROPIC_AUTH_TOKEN`, env: `CLAUDE_CODE_OAUTH_TOKEN`
+Secret: `ANTHROPIC_AUTH_TOKEN`（全ワークフロー共通）
 
 ## Automated Workflows
 

--- a/docs/design/archive/2026-02-01-e2e-tag-filtering-implementation.md
+++ b/docs/design/archive/2026-02-01-e2e-tag-filtering-implementation.md
@@ -650,7 +650,7 @@ jobs:
         continue-on-error: true
         uses: anthropics/claude-code-action@v1
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_code_oauth_token: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
           prompt: |
             Analyze the changes in this PR and determine which E2E test tags should run.
 

--- a/docs/design/infrastructure/daily-cleanup.md
+++ b/docs/design/infrastructure/daily-cleanup.md
@@ -189,7 +189,7 @@ npm run cleanup:manual
    bd create "Review dead code: src/components/OldComponent.tsx"
    ```
 
-2. **Requirements Audit:** Share the same Claude API key (`ANTHROPIC_API_KEY` secret), similar report format
+2. **Requirements Audit:** Share the same Claude API key (`ANTHROPIC_AUTH_TOKEN` secret), similar report format
 
 3. **Branch Cleanup:** Leverage existing `cleanup:branches` script pattern for consistency
 
@@ -242,7 +242,7 @@ npm run cleanup:manual
 
 ### GitHub Secrets Required
 
-- `ANTHROPIC_API_KEY` (already exists for requirements-audit)
+- `ANTHROPIC_AUTH_TOKEN` (already exists for requirements-audit)
 - `GITHUB_TOKEN` (automatically provided by GitHub Actions)
 
 ## Implementation Phases

--- a/docs/design/infrastructure/e2e-testing.md
+++ b/docs/design/infrastructure/e2e-testing.md
@@ -79,7 +79,7 @@ jobs:
         id: claude-analysis
         uses: anthropics/claude-code-action@v1
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_code_oauth_token: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
           prompt: |
             Analyze the changes in this PR and determine which E2E test tags should run.
 

--- a/docs/setup/README.md
+++ b/docs/setup/README.md
@@ -4,10 +4,10 @@
 
 sumitsugiのGitHub Actionsワークフローで使用するSecrets：
 
-| Secret名            | 使用ワークフロー                           | 必須       |
-| ------------------- | ------------------------------------------ | ---------- |
-| `ANTHROPIC_API_KEY` | Requirements Audit, Daily Knowledge Update | ✅ 必須    |
-| `LINEAR_API_KEY`    | Linear統合（将来）                         | オプション |
+| Secret名               | 使用ワークフロー                                                         | 必須       |
+| ---------------------- | ------------------------------------------------------------------------ | ---------- |
+| `ANTHROPIC_AUTH_TOKEN` | Requirements Audit, Daily Standup, Weekly Retrospective, Claude Code CLI | ✅ 必須    |
+| `LINEAR_API_KEY`       | Linear統合（将来）                                                       | オプション |
 
 ---
 
@@ -28,7 +28,7 @@ sumitsugiのGitHub Actionsワークフローで使用するSecrets：
 4. **「New repository secret」ボタンをクリック**
 
 5. **Secretを追加:**
-   - **Name:** `ANTHROPIC_API_KEY`
+   - **Name:** `ANTHROPIC_AUTH_TOKEN`
    - **Value:** [あなたのAnthropic API Key]
    - **「Add secret」をクリック**
 
@@ -41,7 +41,7 @@ sumitsugiのGitHub Actionsワークフローで使用するSecrets：
 source .env.local
 
 # GitHub Secretsに設定
-gh secret set ANTHROPIC_API_KEY --body "$ANTHROPIC_API_KEY"
+gh secret set ANTHROPIC_AUTH_TOKEN --body "$ANTHROPIC_API_KEY"
 ```
 
 **確認:**
@@ -53,7 +53,7 @@ gh secret list
 **出力例:**
 
 ```
-ANTHROPIC_API_KEY  Updated 2026-02-03
+ANTHROPIC_AUTH_TOKEN  Updated 2026-02-03
 ```
 
 ---
@@ -136,7 +136,7 @@ gh run view --log
 2. GitHub Secretsに設定し直す
 3. ワークフローを再実行
 
-### エラー: "secret ANTHROPIC_API_KEY not found"
+### エラー: "secret ANTHROPIC_AUTH_TOKEN not found"
 
 **原因:** Secret名が間違っている、または設定されていない
 
@@ -147,7 +147,7 @@ gh run view --log
 gh secret list
 
 # ANTHROPICで始まるSecretがなければ設定
-gh secret set ANTHROPIC_API_KEY --body "sk-ant-your-key-here"
+gh secret set ANTHROPIC_AUTH_TOKEN --body "sk-ant-your-key-here"
 ```
 
 ### エラー: ".env.local: No such file or directory"
@@ -159,7 +159,7 @@ gh secret set ANTHROPIC_API_KEY --body "sk-ant-your-key-here"
 **確認すべき箇所:**
 
 - スクリプトが `process.env.ANTHROPIC_API_KEY` を使っているか
-- ワークフローが `env: ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}` を設定しているか
+- ワークフローが `env: ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}` を設定しているか
 
 ---
 


### PR DESCRIPTION
## Summary
- Consolidate all GitHub Actions workflows to use a single `ANTHROPIC_AUTH_TOKEN` secret instead of `CLAUDE_CODE_OAUTH_TOKEN` / `ANTHROPIC_API_KEY`
- Migrate daily-standup, requirements-audit, and weekly-retrospective from direct Anthropic API `curl` calls to Claude Code CLI (`claude -p`)
- Update all documentation references to reflect the new secret name

## Changes
- `.github/workflows/claude-code-review.yml` — `CLAUDE_CODE_OAUTH_TOKEN` → `ANTHROPIC_AUTH_TOKEN`
- `.github/workflows/claude.yml` — `CLAUDE_CODE_OAUTH_TOKEN` → `ANTHROPIC_AUTH_TOKEN`
- `.github/workflows/daily-standup.yml` — Migrate from curl API to `claude -p`, use `ANTHROPIC_AUTH_TOKEN`
- `.github/workflows/requirements-audit.yml` — Migrate from curl API to `claude -p`, use `ANTHROPIC_AUTH_TOKEN`
- `.github/workflows/sync-vercel-env.yml` — `ANTHROPIC_API_KEY` → `ANTHROPIC_AUTH_TOKEN`
- `.github/workflows/weekly-retrospective.yml` — Migrate from curl API to `claude -p`, use `ANTHROPIC_AUTH_TOKEN`
- `CLAUDE.md` — Update secret documentation
- `docs/setup/README.md` — Update setup instructions for new secret name
- `docs/design/` — Update secret references in design docs

## Test Plan
- [ ] Verify `claude-code-review.yml` triggers correctly on PRs
- [ ] Verify `claude.yml` triggers correctly on issues/PRs
- [ ] Verify `daily-standup.yml` generates reports using CLI
- [ ] Verify `requirements-audit.yml` runs audit using CLI
- [ ] Verify `weekly-retrospective.yml` generates retrospective using CLI
- [ ] Verify `sync-vercel-env.yml` syncs env vars correctly

Generated with Claude Code