### PR TITLE
chore: rename ANTHROPIC_AUTH_TOKEN to CLAUDE_CODE_OAUTH_TOKEN

### DIFF
--- a/.github/workflows/autonomous-developer.yml
+++ b/.github/workflows/autonomous-developer.yml
@@ -111,7 +111,7 @@ jobs:
         id: claude
         if: steps.pick.outputs.has_task == 'true' && inputs.dry_run != true
         env:
-          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           INPUT_MILESTONE: ${{ inputs.milestone }}
           INPUT_FORCE_ID: ${{ inputs.force_task_id }}
         run: |

--- a/.github/workflows/autonomous-pr-review.yml
+++ b/.github/workflows/autonomous-pr-review.yml
@@ -326,7 +326,7 @@ jobs:
 
       - name: Run Claude Code Review
         env:
-          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
         run: |
           npm install -g @anthropic-ai/claude-code
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -35,7 +35,7 @@ jobs:
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:
-          claude_code_oauth_token: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,7 +34,7 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@v1
         with:
-          claude_code_oauth_token: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |

--- a/.github/workflows/daily-knowledge-update.yml
+++ b/.github/workflows/daily-knowledge-update.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Run daily knowledge update script
         env:
-          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
         run: bun run scripts/daily-knowledge-update.ts
 
       - name: Commit and push changes via PR

--- a/.github/workflows/daily-standup.yml
+++ b/.github/workflows/daily-standup.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Generate standup report
         env:
-          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           REPORT_DATE: ${{ steps.metrics.outputs.today }}
           TASKS_DONE: ${{ steps.metrics.outputs.tasks_done }}
           TASKS_OPEN: ${{ steps.metrics.outputs.tasks_open }}

--- a/.github/workflows/requirements-audit.yml
+++ b/.github/workflows/requirements-audit.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Run Claude Audit
         env:
-          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
         run: |
           REQUIREMENTS=$(cat /tmp/requirements.md)
           BUSINESS=$(cat /tmp/business.md)

--- a/.github/workflows/sync-vercel-env.yml
+++ b/.github/workflows/sync-vercel-env.yml
@@ -46,7 +46,7 @@ jobs:
           R2_PUBLIC_URL: ${{ secrets.R2_PUBLIC_URL }}
           RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
           EMAIL_FROM: ${{ secrets.EMAIL_FROM }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
           STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
           NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY }}

--- a/.github/workflows/weekly-retrospective.yml
+++ b/.github/workflows/weekly-retrospective.yml
@@ -85,7 +85,7 @@ jobs:
 
       - name: Generate retrospective
         env:
-          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           WEEK_START: ${{ steps.metrics.outputs.week_start }}
           WEEK_END: ${{ steps.metrics.outputs.week_end }}
           PRS_MERGED: ${{ steps.metrics.outputs.prs_merged }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ Airbnb風クリーンUI / アクセント: `#FF5A5F` / Lucide React / shadcn/ui 
 ## GitHub Actions (CRITICAL)
 
 Claude Code CLI (`claude -p`) を使用。Anthropic SDKはOAuthトークン非対応。
-Secret: `ANTHROPIC_AUTH_TOKEN`（全ワークフロー共通）
+Secret: `CLAUDE_CODE_OAUTH_TOKEN`（全ワークフロー共通）
 
 ## Automated Workflows
 

--- a/docs/design/archive/2026-02-01-e2e-tag-filtering-implementation.md
+++ b/docs/design/archive/2026-02-01-e2e-tag-filtering-implementation.md
@@ -650,7 +650,7 @@ jobs:
         continue-on-error: true
         uses: anthropics/claude-code-action@v1
         with:
-          claude_code_oauth_token: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
             Analyze the changes in this PR and determine which E2E test tags should run.
 

--- a/docs/design/infrastructure/daily-cleanup.md
+++ b/docs/design/infrastructure/daily-cleanup.md
@@ -189,7 +189,7 @@ npm run cleanup:manual
    bd create "Review dead code: src/components/OldComponent.tsx"
    ```
 
-2. **Requirements Audit:** Share the same Claude API key (`ANTHROPIC_AUTH_TOKEN` secret), similar report format
+2. **Requirements Audit:** Share the same Claude API key (`CLAUDE_CODE_OAUTH_TOKEN` secret), similar report format
 
 3. **Branch Cleanup:** Leverage existing `cleanup:branches` script pattern for consistency
 
@@ -242,7 +242,7 @@ npm run cleanup:manual
 
 ### GitHub Secrets Required
 
-- `ANTHROPIC_AUTH_TOKEN` (already exists for requirements-audit)
+- `CLAUDE_CODE_OAUTH_TOKEN` (already exists for requirements-audit)
 - `GITHUB_TOKEN` (automatically provided by GitHub Actions)
 
 ## Implementation Phases

--- a/docs/design/infrastructure/e2e-testing.md
+++ b/docs/design/infrastructure/e2e-testing.md
@@ -79,7 +79,7 @@ jobs:
         id: claude-analysis
         uses: anthropics/claude-code-action@v1
         with:
-          claude_code_oauth_token: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
             Analyze the changes in this PR and determine which E2E test tags should run.
 

--- a/docs/setup/README.md
+++ b/docs/setup/README.md
@@ -4,10 +4,10 @@
 
 sumitsugiのGitHub Actionsワークフローで使用するSecrets：
 
-| Secret名               | 使用ワークフロー                                                         | 必須       |
-| ---------------------- | ------------------------------------------------------------------------ | ---------- |
-| `ANTHROPIC_AUTH_TOKEN` | Requirements Audit, Daily Standup, Weekly Retrospective, Claude Code CLI | ✅ 必須    |
-| `LINEAR_API_KEY`       | Linear統合（将来）                                                       | オプション |
+| Secret名                  | 使用ワークフロー                                                         | 必須       |
+| ------------------------- | ------------------------------------------------------------------------ | ---------- |
+| `CLAUDE_CODE_OAUTH_TOKEN` | Requirements Audit, Daily Standup, Weekly Retrospective, Claude Code CLI | ✅ 必須    |
+| `LINEAR_API_KEY`          | Linear統合（将来）                                                       | オプション |
 
 ---
 
@@ -28,7 +28,7 @@ sumitsugiのGitHub Actionsワークフローで使用するSecrets：
 4. **「New repository secret」ボタンをクリック**
 
 5. **Secretを追加:**
-   - **Name:** `ANTHROPIC_AUTH_TOKEN`
+   - **Name:** `CLAUDE_CODE_OAUTH_TOKEN`
    - **Value:** [あなたのAnthropic API Key]
    - **「Add secret」をクリック**
 
@@ -41,7 +41,7 @@ sumitsugiのGitHub Actionsワークフローで使用するSecrets：
 source .env.local
 
 # GitHub Secretsに設定
-gh secret set ANTHROPIC_AUTH_TOKEN --body "$ANTHROPIC_API_KEY"
+gh secret set CLAUDE_CODE_OAUTH_TOKEN --body "$ANTHROPIC_API_KEY"
 ```
 
 **確認:**
@@ -53,7 +53,7 @@ gh secret list
 **出力例:**
 
 ```
-ANTHROPIC_AUTH_TOKEN  Updated 2026-02-03
+CLAUDE_CODE_OAUTH_TOKEN  Updated 2026-02-03
 ```
 
 ---
@@ -136,7 +136,7 @@ gh run view --log
 2. GitHub Secretsに設定し直す
 3. ワークフローを再実行
 
-### エラー: "secret ANTHROPIC_AUTH_TOKEN not found"
+### エラー: "secret CLAUDE_CODE_OAUTH_TOKEN not found"
 
 **原因:** Secret名が間違っている、または設定されていない
 
@@ -147,7 +147,7 @@ gh run view --log
 gh secret list
 
 # ANTHROPICで始まるSecretがなければ設定
-gh secret set ANTHROPIC_AUTH_TOKEN --body "sk-ant-your-key-here"
+gh secret set CLAUDE_CODE_OAUTH_TOKEN --body "sk-ant-your-key-here"
 ```
 
 ### エラー: ".env.local: No such file or directory"
@@ -159,7 +159,7 @@ gh secret set ANTHROPIC_AUTH_TOKEN --body "sk-ant-your-key-here"
 **確認すべき箇所:**
 
 - スクリプトが `process.env.ANTHROPIC_API_KEY` を使っているか
-- ワークフローが `env: ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}` を設定しているか
+- ワークフローが `env: ANTHROPIC_API_KEY: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}` を設定しているか
 
 ---
 


### PR DESCRIPTION
## Summary

Renames the GitHub secret `ANTHROPIC_AUTH_TOKEN` to `CLAUDE_CODE_OAUTH_TOKEN` throughout the codebase.

## Changes

- Updated all GitHub workflow files (`.github/workflows/*.yml`)
- Updated `CLAUDE.md` documentation
- Updated `docs/setup/README.md` setup guide  
- Updated design documentation files

## Rationale

The new name `CLAUDE_CODE_OAUTH_TOKEN` better reflects that:
1. This is an OAuth token for Claude Code CLI, not a generic Anthropic API key
2. It aligns with the Claude Code action's parameter name `claude_code_oauth_token`
3. It's clearer about the authentication method being used

## Migration Required

After merging this PR, you'll need to:

1. Rename the GitHub secret from `ANTHROPIC_AUTH_TOKEN` to `CLAUDE_CODE_OAUTH_TOKEN`:

```bash
# Get the current secret value (you'll need to have it stored somewhere)
# Then delete the old secret and create the new one:
gh secret delete ANTHROPIC_AUTH_TOKEN
gh secret set CLAUDE_CODE_OAUTH_TOKEN --body "YOUR_TOKEN_VALUE"
```

OR via the GitHub UI:
- Go to Settings → Secrets and variables → Actions
- Delete `ANTHROPIC_AUTH_TOKEN`
- Create `CLAUDE_CODE_OAUTH_TOKEN` with the same value

## Testing

All workflows will fail until the secret is renamed. This PR can be merged first, then the secret should be renamed immediately after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)